### PR TITLE
Fix broken symlink targets

### DIFF
--- a/appimage/appimage.bzl
+++ b/appimage/appimage.bzl
@@ -71,7 +71,6 @@ appimage = rule(
             executable = True,
             cfg = "exec",
         ),
-        "_directory": attr.string(default = "AppDir"),
     },
     executable = True,
 )

--- a/appimage/private/runfiles.bzl
+++ b/appimage/private/runfiles.bzl
@@ -22,11 +22,7 @@ All docker toolchain and layer info provider references were removed and the met
 
 def _binary_name(ctx):
     """For //foo/bar/baz:blah this would translate to /app/foo/bar/baz/blah"""
-    return "/".join([
-        ctx.attr._directory,
-        ctx.attr.binary.label.package,
-        ctx.attr.binary.label.name,
-    ])
+    return "/".join([ctx.attr.binary.label.package, ctx.attr.binary.label.name])
 
 def _runfiles_dir(ctx):
     """For @foo//bar/baz:blah this would translate to /app/bar/baz/blah.runfiles"""
@@ -70,7 +66,7 @@ def _final_file_path(ctx, f):
 def _layer_emptyfile_path(ctx, name):
     if not name.startswith("external/"):
         # Names that don't start with external are relative to our own workspace.
-        return "/".join([ctx.attr.directory, ctx.workspace_name, name])
+        return "/".join([ctx.workspace_name, name])
 
     # References to workspace-external dependencies, which are identifiable
     # because their path begins with external/, are inconsistent with the
@@ -81,11 +77,11 @@ def _layer_emptyfile_path(ctx, name):
     # so we "fix" the empty files' paths by removing "external/" and basing them
     # directly on the runfiles path.
 
-    return "/".join([ctx.attr.directory, name[len("external/"):]])
+    return "/".join([name[len("external/"):]])
 
 def _layer_file_path(ctx, f):
     """The foo_binary independent location in which we store a particular dependency's file such that it can be shared."""
-    return "/".join([ctx.attr._directory, ctx.workspace_name, f.short_path])
+    return "/".join([ctx.workspace_name, f.short_path])
 
 def _default_runfiles(dep):
     return dep[DefaultInfo].default_runfiles.files

--- a/tests/test_appimage.py
+++ b/tests/test_appimage.py
@@ -1,7 +1,9 @@
 """Test appimages as data deps."""
 
+import shutil
 import subprocess
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -18,6 +20,20 @@ def test_run() -> None:
     cmd = [APPIMAGE, "--appimage-extract-and-run", "--name", "Simon Peter"]
     output = subprocess.run(cmd, check=True, text=True, stdout=subprocess.PIPE).stdout
     assert output == "Hello, Simon Peter!\n"
+
+
+def test_symlinks() -> None:
+    cmd = [APPIMAGE, "--appimage-extract"]
+    try:
+        subprocess.run(cmd, check=True, text=True, stdout=subprocess.PIPE)
+        symlinks_present = False
+        for file in Path("squashfs-root").glob("**/*"):
+            if file.is_symlink():
+                assert file.resolve().exists()
+                symlinks_present = True
+        assert symlinks_present
+    finally:
+        shutil.rmtree("squashfs-root")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Symlinks are incorrectly calculated. This patch should make all symlinks valid.

Before:
```
❯ tree squashfs-root
squashfs-root
├── AppRun
├── AppRun.desktop
├── AppRun.png
└── tests
    ├── test_py -> AppDir/tests/test_py.runfiles/rules_appimage/tests/test_py
    └── test_py.runfiles
        ├── bazel_tools
        │   └── tools
        │       └── python
        │           └── py3wrapper.sh
        ├── __init__.py
        ├── py_deps
        │   ├── __init__.py
        │   └── pypi__click
        │       ├── click
        │       │   ├── _compat.py
        │       │   ├── core.py
        │       │   ├── decorators.py
        │       │   ├── exceptions.py
        │       │   ├── formatting.py
        │       │   ├── globals.py
        │       │   ├── __init__.py
        │       │   ├── parser.py
        │       │   ├── py.typed
        │       │   ├── shell_completion.py
        │       │   ├── _termui_impl.py
        │       │   ├── termui.py
        │       │   ├── testing.py
        │       │   ├── _textwrap.py
        │       │   ├── types.py
        │       │   ├── _unicodefun.py
        │       │   ├── utils.py
        │       │   └── _winconsole.py
        │       ├── click-8.0.3.dist-info
        │       │   ├── LICENSE.rst
        │       │   ├── METADATA
        │       │   ├── RECORD
        │       │   ├── top_level.txt
        │       │   └── WHEEL
        │       └── __init__.py
        └── rules_appimage
            ├── external -> AppDir/tests/test_py.runfiles
            └── tests
                ├── data.txt
                ├── __init__.py
                ├── test.py
                └── test_py

11 directories, 36 files
```

After:
```
❯ tree squashfs-root
squashfs-root
├── AppRun
├── AppRun.desktop
├── AppRun.png
└── tests
    ├── test_py -> test_py.runfiles/rules_appimage/tests/test_py
    └── test_py.runfiles
        ├── bazel_tools
        │   └── tools
        │       └── python
        │           └── py3wrapper.sh
        ├── __init__.py
        ├── py_deps
        │   ├── __init__.py
        │   └── pypi__click
        │       ├── click
        │       │   ├── _compat.py
        │       │   ├── core.py
        │       │   ├── decorators.py
        │       │   ├── exceptions.py
        │       │   ├── formatting.py
        │       │   ├── globals.py
        │       │   ├── __init__.py
        │       │   ├── parser.py
        │       │   ├── py.typed
        │       │   ├── shell_completion.py
        │       │   ├── _termui_impl.py
        │       │   ├── termui.py
        │       │   ├── testing.py
        │       │   ├── _textwrap.py
        │       │   ├── types.py
        │       │   ├── _unicodefun.py
        │       │   ├── utils.py
        │       │   └── _winconsole.py
        │       ├── click-8.0.3.dist-info
        │       │   ├── LICENSE.rst
        │       │   ├── METADATA
        │       │   ├── RECORD
        │       │   ├── top_level.txt
        │       │   └── WHEEL
        │       └── __init__.py
        └── rules_appimage
            ├── external -> ..
            └── tests
                ├── data.txt
                ├── __init__.py
                ├── test.py
                └── test_py

12 directories, 35 files
```