### PR TITLE
Update Skylib to 1.1.1

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -16,9 +16,11 @@ def rules_appimage_deps():
     if "bazel_skylib" not in excludes:
         http_archive(
             name = "bazel_skylib",
-            sha256 = "e5d90f0ec952883d56747b7604e2a15ee36e288bb556c3d0ed33e818a4d971f2",
-            strip_prefix = "bazel-skylib-1.0.2",
-            urls = ["https://github.com/bazelbuild/bazel-skylib/archive/1.0.2.tar.gz"],
+            urls = [
+                "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.1.1/bazel-skylib-1.1.1.tar.gz",
+                "https://github.com/bazelbuild/bazel-skylib/releases/download/1.1.1/bazel-skylib-1.1.1.tar.gz",
+            ],
+            sha256 = "c6966ec828da198c5d9adbaa94c05e3a1c7f21bd012a0b29ba8ddbccb2c93b0d",
         )
 
     if "rules_python" not in excludes:


### PR DESCRIPTION
This fixes:
```
Traceback (most recent call last):
        File "/home/laurenz/.cache/bazel/_bazel_laurenz/a5a1ba7b6df8b0a1a9c5bbd01b7812f3/external/bazel_skylib/rules/native_binary.bzl", line 42, column 22, in _impl
                return _impl_rule(ctx, ctx.attr.is_windows)
        File "/home/laurenz/.cache/bazel/_bazel_laurenz/a5a1ba7b6df8b0a1a9c5bbd01b7812f3/external/bazel_skylib/rules/native_binary.bzl", line 33, column 23, in _impl_rule
                files = depset(items = [out]),
Error in depset: depset() got unexpected keyword argument 'items'
ERROR: /home/laurenz/Documents/Github/rules_appimage/appimage/private/tool/BUILD:5:14: Analysis of target '//appimage/private/tool:appimagetool' failed
```