### PR TITLE
Send appimagetool output to stderr

### DIFF
--- a/appimage/private/tool/tool.py
+++ b/appimage/private/tool/tool.py
@@ -91,7 +91,7 @@ def make_appimage(
         ]
         proc = subprocess.run(cmd, check=False, text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         if not quiet or proc.returncode:
-            print(proc.stdout)
+            print(proc.stdout, file=sys.stderr)
         return proc.returncode
 
 


### PR DESCRIPTION
Make appimagetool output print to stderr instead of stdout when it is printed