### PR TITLE
Prevent accidentally-absolute paths for external binaries

### DIFF
--- a/appimage/private/runfiles.bzl
+++ b/appimage/private/runfiles.bzl
@@ -22,7 +22,9 @@ All docker toolchain and layer info provider references were removed and the met
 
 def _binary_name(ctx):
     """For //foo/bar/baz:blah this would translate to /app/foo/bar/baz/blah"""
-    return "/".join([ctx.attr.binary.label.package, ctx.attr.binary.label.name])
+    if ctx.attr.binary.label.package:
+        return "/".join([ctx.attr.binary.label.package, ctx.attr.binary.label.name])
+    return ctx.attr.binary.label.name
 
 def _runfiles_dir(ctx):
     """For @foo//bar/baz:blah this would translate to /app/bar/baz/blah.runfiles"""


### PR DESCRIPTION
Previously, if ctx.attr.binary.label.package was empty (this can happen in toplevel targets, or external dependencies), the _binary_name function would return a path with a leading /, which messes up path lookups.
With this patch, the leading slash is prevented if the target package is the emtpy string.