### PR TITLE
Allow binary targets in external Bazel repos

### DIFF
--- a/appimage/private/runfiles.bzl
+++ b/appimage/private/runfiles.bzl
@@ -141,7 +141,7 @@ def collect_runfiles_info(ctx):
         symlinks = [struct(linkname = k, target = symlinks[k]) for k in symlinks],
         empty_files = empty_files,
     )
-    workdir = "/".join([_runfiles_dir(ctx), ctx.workspace_name])
+    workdir = "/".join([_runfiles_dir(ctx), ctx.attr.binary.label.workspace_name or ctx.workspace_name])
     return struct(
         files = runfiles_list,
         manifest = manifest,

--- a/appimage/private/tool/tool.py
+++ b/appimage/private/tool/tool.py
@@ -1,6 +1,5 @@
 """Tooling to prepare and build AppImages."""
 
-import hashlib
 import json
 import os
 import shutil
@@ -9,7 +8,7 @@ import sys
 import tempfile
 import textwrap
 from pathlib import Path
-from typing import Dict, Iterable, List, Mapping, Optional, Tuple
+from typing import Dict, Iterable, List, Optional, Tuple
 
 import click
 from rules_python.python.runfiles import runfiles
@@ -128,7 +127,7 @@ def make_appimage(
                 set -eu
                 HERE="$(dirname $0)"
                 cd "${{HERE}}/{workdir}"
-                exec "{entrypoint}" "$@"
+                exec "./{entrypoint}" "$@"
                 """
             )
         )

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -18,6 +18,7 @@ py_binary(
     data = [
         "data.txt",
         "dir",  # this is a relative directory, not a target label
+        ":external_bin.appimage",
     ],
     main = "test.py",
     deps = [requirement("click")],
@@ -38,4 +39,9 @@ py_test(
     srcs = ["test_appimage.py"],
     data = [":appimage_py"],
     deps = [requirement("pytest")],
+)
+
+appimage(
+    name = "external_bin.appimage",
+    binary = "@rules_python//tools:wheelmaker",
 )

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 from pathlib import Path
 
 import click
@@ -8,6 +9,14 @@ def test_datadep() -> None:
     data_dep = Path("tests/data.txt")
     assert data_dep.is_file(), f"{data_dep} does not exist"
     assert (s := data_dep.stat().st_size) == 591, f"{data_dep} has wrong size {s}"
+
+
+def test_external_bin() -> None:
+    external_bin_appimage = Path("tests/external_bin.appimage")
+    assert external_bin_appimage.is_file()
+    cmd = [os.fspath(external_bin_appimage), "--appimage-extract-and-run", "-h"]
+    p = subprocess.run(cmd, text=True, check=False, stderr=subprocess.STDOUT, stdout=subprocess.PIPE)
+    assert "Builds a python wheel" in p.stdout, p.stdout
 
 
 def test_symlinks() -> None:
@@ -49,5 +58,6 @@ def greeter(name: str) -> None:
 
 if __name__ == "__main__":
     test_datadep()
+    test_external_bin()
     test_symlinks()
     greeter()


### PR DESCRIPTION
For a test I'm using `@rules_python//tools:wheelmaker`, which is external to this repo. Without the fix, the test would complain something like this:
```
AssertionError: /tmp/appimage_extracted_b8e1ae75ecd774d7f70b9c24383e1c8b/AppRun: line 5: /tmp/appimage_extracted_b8e1ae75ecd774d7f70b9c24383e1c8b/tools/wheelmaker.runfiles/rules_appimage/tools/wheelmaker: No such file or directory
```
because the workdir is not correct.