### PR TITLE
Fix runfiles symlinks

### DIFF
--- a/tests/BUILD
+++ b/tests/BUILD
@@ -1,6 +1,7 @@
 load("//appimage:appimage.bzl", "appimage", "appimage_test")
 load("@rules_python//python:defs.bzl", "py_binary", "py_test")
 load("@py_deps//:requirements.bzl", "requirement")
+load(":testrules.bzl", "rules_appimage_test_rule")
 
 sh_binary(
     name = "test_sh",
@@ -19,6 +20,7 @@ py_binary(
         "data.txt",
         "dir",  # this is a relative directory, not a target label
         ":external_bin.appimage",
+        ":symlink_and_emptyfile",
     ],
     main = "test.py",
     deps = [requirement("click")],
@@ -44,4 +46,9 @@ py_test(
 appimage(
     name = "external_bin.appimage",
     binary = "@rules_python//tools:wheelmaker",
+)
+
+rules_appimage_test_rule(
+    name = "symlink_and_emptyfile",
+    symlink = "data.txt",
 )

--- a/tests/test.py
+++ b/tests/test.py
@@ -48,6 +48,11 @@ def test_symlinks() -> None:
     assert os.readlink(dir_link) == "dir"
     assert dir_link.resolve().is_dir()
 
+def test_runfiles_symlinks() -> None:
+    runfiles_symlink = Path("path/to/the/runfiles_symlink")
+    assert runfiles_symlink.is_symlink()
+    assert os.readlink(runfiles_symlink) == "../../../tests/data.txt"
+    assert runfiles_symlink.resolve().is_file()
 
 @click.command()
 @click.option("--name", default="world")
@@ -60,4 +65,5 @@ if __name__ == "__main__":
     test_datadep()
     test_external_bin()
     test_symlinks()
+    test_runfiles_symlinks()
     greeter()

--- a/tests/testrules.bzl
+++ b/tests/testrules.bzl
@@ -1,0 +1,12 @@
+"""Bazel rule that creates a runfile symlink."""
+
+def _rules_appimage_test_rule_impl(ctx):
+    runfiles = ctx.runfiles(symlinks = {"path/to/the/runfiles_symlink": ctx.files.symlink[0]})
+    return [DefaultInfo(runfiles = runfiles)]
+
+rules_appimage_test_rule = rule(
+    implementation = _rules_appimage_test_rule_impl,
+    attrs = {
+        "symlink": attr.label(mandatory = True, allow_single_file = True),
+    },
+)


### PR DESCRIPTION
* Remove the unused `_layer_*_path` functions lifted from rules_docker
* Fix the runfiles symlinks target path to be under runfiles where it belongs
* Add a test