### PR TITLE
Upgrade to Skylib 1.3.0

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -17,10 +17,10 @@ def rules_appimage_deps():
         http_archive(
             name = "bazel_skylib",
             urls = [
-                "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.1.1/bazel-skylib-1.1.1.tar.gz",
-                "https://github.com/bazelbuild/bazel-skylib/releases/download/1.1.1/bazel-skylib-1.1.1.tar.gz",
+                "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.3.0/bazel-skylib-1.3.0.tar.gz",
+                "https://github.com/bazelbuild/bazel-skylib/releases/download/1.3.0/bazel-skylib-1.3.0.tar.gz",
             ],
-            sha256 = "c6966ec828da198c5d9adbaa94c05e3a1c7f21bd012a0b29ba8ddbccb2c93b0d",
+            sha256 = "74d544d96f4a5bb630d465ca8bbcfe231e3594e5aae57e1edbf17a6eb3ca2506",
         )
 
     if "rules_python" not in excludes:
@@ -35,6 +35,7 @@ def rules_appimage_deps():
         if name not in excludes:
             http_file(
                 name = name,
+                executable = True,
                 sha256 = sha,
                 urls = ["https://github.com/AppImage/AppImageKit/releases/download/13/appimagetool-{}.AppImage".format(arch)],
             )


### PR DESCRIPTION
The https://github.com/bazelbuild/bazel-skylib/releases/tag/1.3.0 release of Skylib has an incompatible change where a symlink is used for native_binary rules. This can only work if the src is executable so we need to set that as well on the http_file.