### PR TITLE
Replace appimagetool with direct mksquashfs invocation and runtime concatenation

### DIFF
--- a/BazelizedMksquashfs.md
+++ b/BazelizedMksquashfs.md
@@ -1,0 +1,29 @@
+# How to use a bazelized mksquashfs instead of what's on the host.
+
+It's nicer to use a bazel-built mksquashfs than hoping the host supplies one / using whatever version might be installed there.
+
+Dropbox's dbx_build_tools repo provides a bazel-built squashfs-tools plus (some of) its build dependencies.
+You can integrate it like this:
+
+1. Add to WORKSPACE:
+    ```py
+    DBX_BUILD_TOOLS_VERSION = "c083ae0cdec5b2bd1fe929cad56d02b6770c4dd0"
+    http_archive(
+        name = "dbx_build_tools",
+        sha256 = "2267c4c441b9cde94b8c94a9c1e2e2bd3c2c865c45f893224bfbbf9d5d0998a8",
+        urls = ["https://github.com/dropbox/dbx_build_tools/archive/{}.tar.gz".format(DBX_BUILD_TOOLS_VERSION)],
+        strip_prefix = "dbx_build_tools-" + DBX_BUILD_TOOLS_VERSION,
+    )
+    
+    load("@dbx_build_tools//build_tools/bazel:external_workspace.bzl", "drte_deps")
+    drte_deps()
+    ```
+2.  Use `"@com_github_plougher_squashfs_tools//:mksquashfs"` as the `mksquashfs` attr of all your `appimage` rules.
+    Hint: You could create a custom wrapper macro like below.
+    ```py
+    load("//appimage:appimage.bzl", _appimage="appimage")
+
+    def appimage(name, **kwargs):
+        kwargs["mksquashfs"] = "@com_github_plougher_squashfs_tools//:mksquashfs"
+        _appimage(name = name, **kwargs)
+    ```

--- a/appimage/appimage.bzl
+++ b/appimage/appimage.bzl
@@ -6,15 +6,12 @@ def _appimage_impl(ctx):
     """Implementation of the appimage rule."""
     tools = depset(
         direct = [ctx.executable._tool],
-        transitive = [ctx.attr._tool[DefaultInfo].default_runfiles.files],
+        transitive = [ctx.attr._tool[DefaultInfo].default_runfiles.files] + [depset(ctx.files.mksquashfs)],
     )
-
     runfile_info = collect_runfiles_info(ctx)
     manifest_file = ctx.actions.declare_file(ctx.attr.name + "-manifest.json")
     ctx.actions.write(manifest_file, json.encode_indent(runfile_info.manifest))
-    inputs = depset(
-        direct = [ctx.file.icon, manifest_file] + runfile_info.files,
-    )
+    inputs = depset(direct = [ctx.file.icon, manifest_file] + runfile_info.files)
 
     # TODO: Use Skylib's shell.quote?
     args = [
@@ -24,7 +21,7 @@ def _appimage_impl(ctx):
         "--icon={}".format(ctx.file.icon.path),
     ]
     if ctx.attr.mksquashfs:
-        args.append("--mksquashfs_path={}".format(ctx.attr.mksquashfs))
+        args.append("--mksquashfs_path={}".format(ctx.file.mksquashfs.path))
     args.extend(["--mksquashfs_arg=" + arg for arg in ctx.attr.build_args])
     args.append(ctx.outputs.executable.path)
 

--- a/appimage/appimage.bzl
+++ b/appimage/appimage.bzl
@@ -23,10 +23,9 @@ def _appimage_impl(ctx):
         "--entrypoint={}".format(runfile_info.entrypoint),
         "--icon={}".format(ctx.file.icon.path),
     ]
-
-    args.extend(["--extra_arg=" + arg for arg in ctx.attr.build_args])
-    if ctx.attr.quiet:
-        args.append("--quiet")
+    if ctx.attr.mksquashfs:
+        args.append("--mksquashfs_path={}".format(ctx.attr.mksquashfs))
+    args.extend(["--mksquashfs_arg=" + arg for arg in ctx.attr.build_args])
     args.append(ctx.outputs.executable.path)
 
     ctx.actions.run(
@@ -51,37 +50,13 @@ def _appimage_impl(ctx):
     ]
 
 _ATTRS = {
-    "binary": attr.label(
-        executable = True,
-        cfg = "target",
-    ),
-    "icon": attr.label(
-        default = "@AppImageKit//:resources/appimagetool.png",
-        allow_single_file = True,
-    ),
-    "build_args": attr.string_list(
-        default = [
-            "--appimage-extract-and-run",
-            "--no-appstream",
-        ],
-    ),
-    "build_env": attr.string_dict(
-        default = {
-            "ARCH": "x86_64",
-            "NO_CLEANUP": "1",
-        },
-    ),
-    "quiet": attr.bool(
-        default = True,
-    ),
-    "_tool": attr.label(
-        default = "//appimage/private/tool",
-        executable = True,
-        cfg = "exec",
-    ),
-    "env": attr.string_dict(
-        doc = "Runtime environment variables. See https://bazel.build/reference/be/common-definitions#common-attributes-tests",
-    ),
+    "binary": attr.label(executable = True, cfg = "target"),
+    "icon": attr.label(default = "@appimagetool.png//file", allow_single_file = True),
+    "mksquashfs": attr.label(default = None, executable = True, allow_single_file = True, cfg = "host"),
+    "build_args": attr.string_list(),
+    "build_env": attr.string_dict(),
+    "_tool": attr.label(default = "//appimage/private/tool", executable = True, cfg = "exec"),
+    "env": attr.string_dict(doc = "Runtime environment variables. See https://bazel.build/reference/be/common-definitions#common-attributes-tests"),
 }
 
 appimage = rule(

--- a/appimage/private/tool/BUILD
+++ b/appimage/private/tool/BUILD
@@ -1,24 +1,24 @@
 load("@rules_python//python:defs.bzl", "py_binary")
-load("@bazel_skylib//rules:native_binary.bzl", "native_binary")
+load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@py_deps//:requirements.bzl", "requirement")
 
-native_binary(
-    name = "appimagetool",
+copy_file(
+    name = "appimage_runtime_copy",
     src = select({
-        "@platforms//cpu:x86_64": "@appimagetool_release_x86_64//file",
-        "@platforms//cpu:arm64": "@appimagetool_release_aarch64//file",
-        "@platforms//cpu:armv7e-m": "@appimagetool_release_armhf//file",
-        "@platforms//cpu:i386": "@appimagetool_release_i686//file",
+        "@platforms//cpu:x86_64": "@appimage_runtime_x86_64//file",
+        "@platforms//cpu:arm64": "@appimage_runtime_aarch64//file",
+        "@platforms//cpu:armv7e-m": "@appimage_runtime_armhf//file",
+        "@platforms//cpu:i386": "@appimage_runtime_i686//file",
     }),
-    out = "appimagetool.bin",
-    target_compatible_with = ["@platforms//os:linux"],
-    visibility = ["//visibility:public"],
+    out = "appimage_runtime",
+    allow_symlink = True,
+    is_executable = True,
 )
 
 py_binary(
     name = "tool",
     srcs = ["tool.py"],
-    data = [":appimagetool"],
+    data = [":appimage_runtime"],
     python_version = "PY3",
     visibility = ["//visibility:public"],
     deps = [

--- a/appimage/private/tool/tests/test_tool.py
+++ b/appimage/private/tool/tests/test_tool.py
@@ -10,10 +10,10 @@ import rules_appimage.appimage.private.tool.tool as tool
 
 
 def test_appimagetool() -> None:
-    cmd = [tool.APPIMAGE_TOOL, "--appimage-extract-and-run", "--version"]
+    cmd = [os.fspath(tool.APPIMAGE_RUNTIME), "--appimage-version"]
     output = subprocess.run(cmd, check=True, text=True, stderr=subprocess.PIPE).stderr
 
-    assert output.splitlines()[-1].startswith("appimagetool")
+    assert output.splitlines()[-1].startswith("Version: ")
 
 
 def test_cli() -> None:

--- a/deps.bzl
+++ b/deps.bzl
@@ -2,11 +2,11 @@
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
 
-APPIMAGETOOL_RELEASES = {
-    "aarch64": "334e77beb67fc1e71856c29d5f3f324ca77b0fde7a840fdd14bd3b88c25c341f",
-    "armhf": "36bb718f32002357375d77b082c264baba2a2dcf44ed1a27d51dbb528fbb60f6",
-    "i686": "104978205c888cb2ad42d1799e03d4621cb9a6027cfb375d069b394a82ff15d1",
-    "x86_64": "df3baf5ca5facbecfc2f3fa6713c29ab9cefa8fd8c1eac5d283b79cab33e4acb",
+APPIMAGE_RUNTIME_RELEASES = {
+    "aarch64": "d2624ce8cc2c64ef76ba986166ad67f07110cdbf85112ace4f91611bc634c96a",
+    "armhf": "c143d8981702b91cc693e5d31ddd91e8424fec5911fa2dda72082183b2523f47",
+    "i686": "5cbfd3c7e78d9ebb16b9620b28affcaa172f2166f1ef5fe7ef878699507bcd7f",
+    "x86_64": "328e0d745c5c6817048c27bc3e8314871703f8f47ffa81a37cb06cd95a94b323",
 }
 
 def rules_appimage_deps():
@@ -30,21 +30,19 @@ def rules_appimage_deps():
             sha256 = "cd6730ed53a002c56ce4e2f396ba3b3be262fd7cb68339f0377a45e8227fe332",
         )
 
-    for arch, sha in APPIMAGETOOL_RELEASES.items():
-        name = "appimagetool_release_" + arch
+    for arch, sha in APPIMAGE_RUNTIME_RELEASES.items():
+        name = "appimage_runtime_" + arch
         if name not in excludes:
             http_file(
                 name = name,
                 executable = True,
                 sha256 = sha,
-                urls = ["https://github.com/AppImage/AppImageKit/releases/download/13/appimagetool-{}.AppImage".format(arch)],
+                urls = ["https://github.com/AppImage/AppImageKit/releases/download/13/runtime-{}".format(arch)],
             )
 
-    if "AppImageKit" not in excludes:
-        http_archive(
-            name = "AppImageKit",
-            sha256 = "51b837c78dd99ecc1cf3dd283f4a98a1be665b01457da0edc1ff736d12974b1a",
-            urls = ["https://github.com/AppImage/AppImageKit/archive/refs/tags/13.tar.gz"],
-            build_file_content = 'exports_files(glob(["**"]))',
-            strip_prefix = "AppImageKit-13",
+    if "appimagetool.png" not in excludes:
+        http_file(
+            name = "appimagetool.png",
+            sha256 = "0c23daaf7665216a8e8f9754c904ec18b2dfa376af2479601a571e504239fae6",
+            urls = ["https://raw.githubusercontent.com/AppImage/AppImageKit/b51f685/resources/appimagetool.png"],
         )

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -10,7 +10,7 @@ sh_binary(
 
 appimage_test(
     name = "appimage_test_sh",
-    args = ["--appimage-extract-and-run"],
+    args = ["--appimage-extract-and-run"],  # One way to run if no libfuse2 is available
     binary = ":test_sh",
 )
 
@@ -30,12 +30,17 @@ py_binary(
 appimage_test(
     name = "appimage_test_py",
     binary = ":test_py",
-    env = {"APPIMAGE_EXTRACT_AND_RUN": "1"},
+    env = {"APPIMAGE_EXTRACT_AND_RUN": "1"},  # Another way to run if no libfuse2 is available
 )
 
 appimage(
     name = "appimage_py",
     binary = ":test_py",
+    build_args = [
+        # Example: Compress the squashfs inside with xz instead of gzip.
+        "-comp",
+        "xz",
+    ],
 )
 
 py_test(
@@ -48,6 +53,10 @@ py_test(
 appimage(
     name = "external_bin.appimage",
     binary = "@rules_python//tools:wheelmaker",
+    build_env = {
+        # Example: Set environment variable for mksquashfs to set all file timestamps to 1970-01-01.
+        "SOURCE_DATE_EPOCH": "0",
+    },
 )
 
 rules_appimage_test_rule(

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -37,9 +37,9 @@ appimage(
     name = "appimage_py",
     binary = ":test_py",
     build_args = [
-        # Example: Compress the squashfs inside with xz instead of gzip.
+        # Example: Compress the squashfs with gzip (this is usually the default).
         "-comp",
-        "xz",
+        "gzip",
     ],
 )
 


### PR DESCRIPTION
Until now, rules_appimage used `appimagetool` from https://github.com/AppImage/AppImageKit to create the actual .AppImage artifact from the prepared AppDir. This works but does not provide much value add over creating the squashfs ourselves and concating it to an appimage runtime (which is essentially what appimagetool does).

This PR replaces appimagetool with this process. The big advantages are:
* Can provide a custom mksquashfs to use
* Can completely customize all mksquashfs options
* Easier to replace the AppImage runtime, e.g. with the upcoming static one that includes libfuse3 in it.