### PR TITLE
Replace RunEnvironmentInfo with TestEnvironment

### DIFF
--- a/appimage/appimage.bzl
+++ b/appimage/appimage.bzl
@@ -39,9 +39,7 @@ def _appimage_impl(ctx):
             files = depset([ctx.outputs.executable]),
             runfiles = ctx.runfiles(files = [ctx.outputs.executable]),
         ),
-        RunEnvironmentInfo(
-            environment = ctx.attr.env,
-        ),
+        testing.TestEnvironment(ctx.attr.env),
     ]
 
 _ATTRS = {


### PR DESCRIPTION
RunEnvironmentInfo is only available in Bazel >= 5.3

testing.TestEnvironment is deprecated in latest Bazel, but at least it works even on Bazel 4 :) https://bazel.build/rules/lib/testing#TestEnvironment

Closes https://github.com/lalten/rules_appimage/issues/29