### PR TITLE
Use `-warnings all` with buildifier

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,7 @@ jobs:
           restore-keys: lint-
 
       - run: go install github.com/bazelbuild/buildtools/buildifier@latest
-      - run: ~/go/bin/buildifier --lint=warn --mode=check -v -r .
+      - run: ~/go/bin/buildifier --lint=warn --mode=check -warnings all -v -r .
 
       - uses: actions/setup-node@v3
       - uses: xt0rted/markdownlint-problem-matcher@v1

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ bazel test //...
 And run the [linters](.github/workflows/ci.yaml):
 
 ```sh
-buildifier lint=warn -r .
+buildifier -lint=fix -warnings all -r .
 markdownlint .
 yamllint --strict .
 pylint .

--- a/appimage/appimage.bzl
+++ b/appimage/appimage.bzl
@@ -44,11 +44,11 @@ def _appimage_impl(ctx):
 
 _ATTRS = {
     "binary": attr.label(executable = True, cfg = "target"),
-    "icon": attr.label(default = "@appimagetool.png//file", allow_single_file = True),
     "build_args": attr.string_list(),
     "build_env": attr.string_dict(),
-    "_tool": attr.label(default = "//appimage/private/tool", executable = True, cfg = "exec"),
     "env": attr.string_dict(doc = "Runtime environment variables. See https://bazel.build/reference/be/common-definitions#common-attributes-tests"),
+    "icon": attr.label(default = "@appimagetool.png//file", allow_single_file = True),
+    "_tool": attr.label(default = "//appimage/private/tool", executable = True, cfg = "exec"),
 }
 
 appimage = rule(

--- a/appimage/private/tool/BUILD
+++ b/appimage/private/tool/BUILD
@@ -1,13 +1,13 @@
-load("@rules_python//python:defs.bzl", "py_binary")
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
+load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 
 copy_file(
     name = "appimage_runtime_copy",
     src = select({
-        "@platforms//cpu:x86_64": "@appimage_runtime_x86_64//file",
         "@platforms//cpu:arm64": "@appimage_runtime_aarch64//file",
         "@platforms//cpu:armv7e-m": "@appimage_runtime_armhf//file",
         "@platforms//cpu:i386": "@appimage_runtime_i686//file",
+        "@platforms//cpu:x86_64": "@appimage_runtime_x86_64//file",
     }),
     out = "appimage_runtime",
     allow_symlink = True,
@@ -17,10 +17,10 @@ copy_file(
 copy_file(
     name = "mksquashfs_copy",
     src = select({
-        "@platforms//cpu:x86_64": "@mksquashfs_x86_64//file",
         "@platforms//cpu:arm64": "@mksquashfs_aarch64//file",
         "@platforms//cpu:armv7e-m": "@mksquashfs_armhf//file",
         "@platforms//cpu:i386": "@mksquashfs_i686//file",
+        "@platforms//cpu:x86_64": "@mksquashfs_x86_64//file",
     }),
     out = "mksquashfs",
     allow_symlink = True,

--- a/appimage/private/tool/tests/BUILD
+++ b/appimage/private/tool/tests/BUILD
@@ -1,5 +1,5 @@
-load("@rules_python//python:defs.bzl", "py_test")
 load("@py_deps//:requirements.bzl", "requirement")
+load("@rules_python//python:defs.bzl", "py_test")
 
 py_test(
     name = "test_cli",

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -1,6 +1,6 @@
-load("//appimage:appimage.bzl", "appimage", "appimage_test")
-load("@rules_python//python:defs.bzl", "py_binary", "py_test")
 load("@py_deps//:requirements.bzl", "requirement")
+load("@rules_python//python:defs.bzl", "py_binary", "py_test")
+load("//appimage:appimage.bzl", "appimage", "appimage_test")
 load(":testrules.bzl", "rules_appimage_test_rule")
 
 sh_binary(


### PR DESCRIPTION
Turn on all the warnings that are disabled by default. See https://github.com/bazelbuild/buildtools/blob/master/buildifier/README.md#linter