### PR TITLE
Propagate env attr

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,6 +28,9 @@ jobs:
           sed --in-place "s/${TO_REPLACE}/${REPLACE_WITH}/" WORKSPACE
           bazel run //:requirements.update
 
+      - run: sed -i '/remove if Bazel version < 6/d' tests/test.cc
+        if: ${{ startsWith(matrix.bazel-version, '5') }}
+
       - name: Run tests
         run: bazel test --test_env=NO_CLEANUP=1 //...
 

--- a/appimage/appimage.bzl
+++ b/appimage/appimage.bzl
@@ -35,7 +35,13 @@ def _appimage_impl(ctx):
     ctx.actions.run_shell(
         outputs = [env_file],
         env = env,
-        command = "export -p > " + env_file.path,
+        command = "".join([
+            "export -p",
+            # Some shells like to use `declare -x` instead of `export`. However there is no guarantee that `declare` is
+            # available at runtime. So let's use `export` instead.
+            " | sed 's/^declare -x/export/'",
+            " > " + env_file.path,
+        ]),
     )
 
     # Run our tool to create the AppImage

--- a/appimage/appimage.bzl
+++ b/appimage/appimage.bzl
@@ -33,9 +33,10 @@ def _appimage_impl(ctx):
         tools = tools,
     )
 
-    env = dict(ctx.attr.env)
+    env = {}
     if RunEnvironmentInfo in ctx.attr.binary:
         env.update(ctx.attr.binary[RunEnvironmentInfo].environment)
+    env.update(ctx.attr.env)
 
     return [
         DefaultInfo(

--- a/appimage/appimage.bzl
+++ b/appimage/appimage.bzl
@@ -25,6 +25,7 @@ def _appimage_impl(ctx):
     args.extend(["--mksquashfs_arg=" + arg for arg in ctx.attr.build_args])
     args.append(ctx.outputs.executable.path)
 
+    # Take the `binary` env and add the appimage target's env on top of it
     env = {}
     if RunEnvironmentInfo in ctx.attr.binary:
         env.update(ctx.attr.binary[RunEnvironmentInfo].environment)

--- a/appimage/appimage.bzl
+++ b/appimage/appimage.bzl
@@ -33,13 +33,17 @@ def _appimage_impl(ctx):
         tools = tools,
     )
 
+    env = dict(ctx.attr.env)
+    if RunEnvironmentInfo in ctx.attr.binary:
+        env.update(ctx.attr.binary[RunEnvironmentInfo].environment)
+
     return [
         DefaultInfo(
             executable = ctx.outputs.executable,
             files = depset([ctx.outputs.executable]),
             runfiles = ctx.runfiles(files = [ctx.outputs.executable]),
         ),
-        testing.TestEnvironment(ctx.attr.env),
+        RunEnvironmentInfo(env),
     ]
 
 _ATTRS = {

--- a/appimage/private/tool/cli.py
+++ b/appimage/private/tool/cli.py
@@ -15,7 +15,13 @@ def parse_args(args: Optional[Sequence[str]] = None) -> argparse.Namespace:
         "--manifest",
         required=True,
         type=Path,
-        help="Path to manifest json with file and link defintions, e.g. 'bazel-bin/tests/appimage_py-manifest.json'",
+        help="Path to manifest json with file and link definitions, e.g. 'bazel-bin/tests/appimage_py-manifest.json'",
+    )
+    parser.add_argument(
+        "--envfile",
+        required=True,
+        type=Path,
+        help="Path to sourcable envfile with runtime environment definition, e.g. 'bazel-bin/tests/appimage_py-env.sh'",
     )
     parser.add_argument(
         "--workdir",
@@ -45,7 +51,9 @@ def parse_args(args: Optional[Sequence[str]] = None) -> argparse.Namespace:
 def cli(args: Optional[Sequence[str]] = None) -> None:
     """CLI entrypoint for mkappimage."""
     parsed_args = parse_args(args)
-    appdir_params = AppDirParams(parsed_args.manifest, parsed_args.workdir, parsed_args.entrypoint, parsed_args.icon)
+    appdir_params = AppDirParams(
+        parsed_args.manifest, parsed_args.envfile, parsed_args.workdir, parsed_args.entrypoint, parsed_args.icon
+    )
     make_appimage(appdir_params, parsed_args.mksquashfs_arg or [], parsed_args.output)
 
 

--- a/appimage/private/tool/mkappimage.py
+++ b/appimage/private/tool/mkappimage.py
@@ -19,6 +19,7 @@ class AppDirParams(NamedTuple):
     """Parameters for the AppDir."""
 
     manifest: Path
+    envfile: Path
     workdir: Path
     entrypoint: Path
     icon: Path
@@ -115,6 +116,7 @@ def populate_appdir(appdir: Path, params: AppDirParams) -> None:
         "\n".join(
             [
                 "#!/bin/sh",
+                *params.envfile.read_text().splitlines(),
                 # If running as AppImage outside Bazel, conveniently set BUILD_WORKING_DIRECTORY, like `bazel run` would
                 # `$OWD` ("Original Working Directory") is set by the AppImage runtime in
                 # https://github.com/lalten/type2-runtime/blob/84f7a00/src/runtime/runtime.c#L1757

--- a/appimage/private/tool/mkappimage.py
+++ b/appimage/private/tool/mkappimage.py
@@ -116,6 +116,7 @@ def populate_appdir(appdir: Path, params: AppDirParams) -> None:
         "\n".join(
             [
                 "#!/bin/sh",
+                # Set up the previously `export -p`ed environment
                 *params.envfile.read_text().splitlines(),
                 # If running as AppImage outside Bazel, conveniently set BUILD_WORKING_DIRECTORY, like `bazel run` would
                 # `$OWD` ("Original Working Directory") is set by the AppImage runtime in

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -60,10 +60,7 @@ py_binary(
         ":external_bin.appimage",
         ":symlink_and_emptyfile",
     ],
-    env = {
-        "MY_BINARY_ENV": "not lost",
-        "MY_APPIMAGE_ENV": "original",
-    },
+    env = {"MY_BINARY_ENV": "not propagated by rules_python :("},
     main = "test.py",
 )
 
@@ -71,10 +68,7 @@ appimage_test(
     name = "appimage_test_py",
     size = "small",
     binary = ":test_py",
-    env = {
-        "APPIMAGE_EXTRACT_AND_RUN": "1",  # Another way to run if no libfuse2 is available
-        "MY_APPIMAGE_ENV": "overwritten",
-    },
+    env = {"APPIMAGE_EXTRACT_AND_RUN": "1"},  # Another way to run if no libfuse2 is available
 )
 
 appimage(

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -1,4 +1,5 @@
 load("@rules_appimage_py_deps//:requirements.bzl", "requirement")
+load("@rules_cc//cc:defs.bzl", "cc_binary")
 load("@rules_python//python:defs.bzl", "py_binary", "py_test")
 load("//appimage:appimage.bzl", "appimage", "appimage_test")
 load(":testrules.bzl", "rules_appimage_test_rule")
@@ -31,8 +32,8 @@ cc_binary(
     name = "test_cc",
     srcs = ["test.cc"],
     env = {
-        "MY_BINARY_ENV": "not lost",
         "MY_APPIMAGE_ENV": "original",
+        "MY_BINARY_ENV": "not lost",
     },
 )
 

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -44,6 +44,13 @@ appimage_test(
     tags = ["requires-fakeroot"],
 )
 
+sh_test(
+    name = "appimage_test_cc_with_sh_test",
+    size = "small",
+    srcs = ["appimage_test_cc_with_sh_test.sh"],
+    data = [":appimage_test_cc"],
+)
+
 py_binary(
     name = "test_py",
     srcs = ["test.py"],

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -27,6 +27,23 @@ appimage_test(
     tags = ["requires-fakeroot"],  # This helps tests failing with `fusermount3: mount failed: Operation not permitted`
 )
 
+cc_binary(
+    name = "test_cc",
+    srcs = ["test.cc"],
+    env = {
+        "MY_BINARY_ENV": "not lost",
+        "MY_APPIMAGE_ENV": "original",
+    },
+)
+
+appimage_test(
+    name = "appimage_test_cc",
+    size = "small",
+    binary = ":test_cc",
+    env = {"MY_APPIMAGE_ENV": "overwritten"},  # environment variables are propagated from the binary target env attr
+    tags = ["requires-fakeroot"],
+)
+
 py_binary(
     name = "test_py",
     srcs = ["test.py"],
@@ -36,6 +53,10 @@ py_binary(
         ":external_bin.appimage",
         ":symlink_and_emptyfile",
     ],
+    env = {
+        "MY_BINARY_ENV": "not lost",
+        "MY_APPIMAGE_ENV": "original",
+    },
     main = "test.py",
 )
 
@@ -43,7 +64,10 @@ appimage_test(
     name = "appimage_test_py",
     size = "small",
     binary = ":test_py",
-    env = {"APPIMAGE_EXTRACT_AND_RUN": "1"},  # Another way to run if no libfuse2 is available
+    env = {
+        "APPIMAGE_EXTRACT_AND_RUN": "1",  # Another way to run if no libfuse2 is available
+        "MY_APPIMAGE_ENV": "overwritten",
+    },
 )
 
 appimage(

--- a/tests/appimage_test_cc_with_sh_test.sh
+++ b/tests/appimage_test_cc_with_sh_test.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -eux
+
+exec env --ignore-environment "tests/appimage_test_cc" --appimage-extract-and-run

--- a/tests/test.cc
+++ b/tests/test.cc
@@ -18,7 +18,7 @@ int main(int argc, char** argv, char** envp) {
   }
   if (!have_binary_env) {
     std::cerr << "MY_BINARY_ENV not found or has wrong value" << std::endl;
-    return EXIT_FAILURE;
+    return EXIT_FAILURE;  // remove if Bazel version < 6
   }
   if (!have_appimage_env) {
     std::cerr << "MY_APPIMAGE_ENV not found or has wrong value" << std::endl;

--- a/tests/test.cc
+++ b/tests/test.cc
@@ -16,8 +16,13 @@ int main(int argc, char** argv, char** envp) {
       have_appimage_env = true;
     }
   }
-  if (have_binary_env && have_appimage_env) {
-    return EXIT_SUCCESS;
+  if (!have_binary_env) {
+    std::cerr << "MY_BINARY_ENV not found or has wrong value" << std::endl;
+    return EXIT_FAILURE;
   }
-  return EXIT_FAILURE;
+  if (!have_appimage_env) {
+    std::cerr << "MY_APPIMAGE_ENV not found or has wrong value" << std::endl;
+    return EXIT_FAILURE;
+  }
+  return EXIT_SUCCESS;
 }

--- a/tests/test.cc
+++ b/tests/test.cc
@@ -1,0 +1,23 @@
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+int main(int argc, char** argv, char** envp) {
+  // Go through the environment variables and find the one we set in the BUILD.
+  // When running inside the appimage, we want the env to not be lost.
+  bool have_binary_env = false;
+  bool have_appimage_env = false;
+  for (char** env = envp; *env != 0; env++) {
+    char* thisEnv = *env;
+    std::cout << thisEnv << std::endl;
+    if (std::string(thisEnv) == "MY_BINARY_ENV=not lost") {
+      have_binary_env = true;
+    } else if (std::string(thisEnv) == "MY_APPIMAGE_ENV=overwritten") {
+      have_appimage_env = true;
+    }
+  }
+  if (have_binary_env && have_appimage_env) {
+    return EXIT_SUCCESS;
+  }
+  return EXIT_FAILURE;
+}

--- a/tests/test.py
+++ b/tests/test.py
@@ -69,6 +69,14 @@ def test_runfiles_symlinks() -> None:
     assert runfiles_symlink.resolve().is_file()
 
 
+def test_binary_env() -> None:
+    """Test that env attr on the binary target is handled."""
+    # Unfortunately rules_python does not seem to set the RunEnvironmentInfo provider.
+    # See https://github.com/bazelbuild/rules_python/issues/901
+    assert "MY_BINARY_ENV" not in os.environ
+    # assert os.environ["MY_BINARY_ENV"] == "not lost"
+
+
 def greeter() -> None:
     """Greet the user."""
     parser = argparse.ArgumentParser()
@@ -82,4 +90,5 @@ if __name__ == "__main__":
     test_external_bin()
     test_symlinks()
     test_runfiles_symlinks()
+    test_binary_env()
     greeter()

--- a/tests/tool/tests/test_cli.py
+++ b/tests/tool/tests/test_cli.py
@@ -15,6 +15,8 @@ def test_cli() -> None:
         [
             "--manifest",
             "manifest.json",
+            "--envfile",
+            "envfile.sh",
             "--workdir",
             "workdir",
             "--entrypoint",
@@ -28,6 +30,7 @@ def test_cli() -> None:
     )
     assert args == argparse.Namespace(
         manifest=Path("manifest.json"),
+        envfile=Path("envfile.sh"),
         workdir=Path("workdir"),
         entrypoint=Path("entrypoint"),
         icon=Path("icon"),

--- a/tests/tool/tests/test_mkappimage.py
+++ b/tests/tool/tests/test_mkappimage.py
@@ -31,7 +31,7 @@ def fake_make_squashfs(_params: mkappimage.AppDirParams, _mksquashfs_params: Ite
 @mock.patch("appimage.private.tool.mkappimage.make_squashfs", fake_make_squashfs)
 def test_make_appimage() -> None:
     """Test that the AppImage is created by concatenating the runtime and the squashfs."""
-    params = mkappimage.AppDirParams(Path(), Path(), Path(), Path())
+    params = mkappimage.AppDirParams(Path(), Path(), Path(), Path(), Path())
     mkappimage.make_appimage(params, [], Path("fake.appimage"))
     appimage = Path("fake.appimage").read_bytes()
     assert appimage.startswith(mkappimage.APPIMAGE_RUNTIME.read_bytes())


### PR DESCRIPTION
This PR improves environment handling:
* The `env` of the `binary` target is kept if the target rule supports it
* That `env` dict is updated with the `env` attr of the appimage target
* The resulting environment is set up in the Appimage entrypoint. This means the `env` attrs have an effect even if not running through Bazel, but in a standalone Appimage.

Fixes https://github.com/lalten/rules_appimage/issues/53