### PR TITLE
Add a data attribute to add additional runfiles to the appimage

### DIFF
--- a/appimage/appimage.bzl
+++ b/appimage/appimage.bzl
@@ -68,6 +68,7 @@ _ATTRS = {
     "binary": attr.label(executable = True, cfg = "target"),
     "build_args": attr.string_list(),
     "build_env": attr.string_dict(),
+    "data": attr.label_list(allow_files = True, doc = "Any additional data that will be made available inside the appimage"),
     "env": attr.string_dict(doc = "Runtime environment variables. See https://bazel.build/reference/be/common-definitions#common-attributes-tests"),
     "icon": attr.label(default = "@appimagetool.png//file", allow_single_file = True),
     "_tool": attr.label(default = "//appimage/private/tool", executable = True, cfg = "exec"),

--- a/appimage/private/runfiles.bzl
+++ b/appimage/private/runfiles.bzl
@@ -87,15 +87,16 @@ def collect_runfiles_info(ctx):
     Returns:
         struct with infos about files needed by app.
     """
-    runfiles_list = _default_runfiles(ctx.attr.binary).to_list()
-    file_map = {_final_file_path(ctx, f): f for f in runfiles_list}
+    runfiles_list = depset(ctx.files.data, transitive = [_default_runfiles(ctx.attr.binary)] + [_default_runfiles(d) for d in ctx.attr.data]).to_list()
+    symlinks_list = depset(transitive = [_default_symlinks(ctx.attr.binary)] + [_default_symlinks(d) for d in ctx.attr.data]).to_list()
+    emptyfiles_list = depset(transitive = [_default_emptyfiles(ctx.attr.binary)] + [_default_emptyfiles(d) for d in ctx.attr.data]).to_list()
 
-    emptyfiles_list = _default_emptyfiles(ctx.attr.binary).to_list()
+    file_map = {_final_file_path(ctx, f): f for f in runfiles_list}
     empty_files = [_final_emptyfile_path(ctx, f) for f in emptyfiles_list]
 
     symlinks = {
         (_reference_dir(ctx) + "/" + sl.path): _final_file_path(ctx, sl.target_file)
-        for sl in _default_symlinks(ctx.attr.binary).to_list()
+        for sl in symlinks_list
     }
     entrypoint = _binary_name(ctx)
     symlinks.update({

--- a/appimage/private/runfiles.bzl
+++ b/appimage/private/runfiles.bzl
@@ -87,6 +87,8 @@ def collect_runfiles_info(ctx):
     Returns:
         struct with infos about files needed by app.
     """
+
+    # Collect everything that needs to be in the appimage and deduplicate using depset.
     runfiles_list = depset(ctx.files.data, transitive = [_default_runfiles(ctx.attr.binary)] + [_default_runfiles(d) for d in ctx.attr.data]).to_list()
     symlinks_list = depset(transitive = [_default_symlinks(ctx.attr.binary)] + [_default_symlinks(d) for d in ctx.attr.data]).to_list()
     emptyfiles_list = depset(transitive = [_default_emptyfiles(ctx.attr.binary)] + [_default_emptyfiles(d) for d in ctx.attr.data]).to_list()

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -65,10 +65,19 @@ py_binary(
     main = "test.py",
 )
 
+filegroup(
+    name = "appimage_data_filegroup",
+    srcs = ["appimage_data_filegroup.txt"],
+)
+
 appimage_test(
     name = "appimage_test_py",
     size = "small",
     binary = ":test_py",
+    data = [
+        "appimage_data_file.txt",
+        ":appimage_data_filegroup",
+    ],
     env = {"APPIMAGE_EXTRACT_AND_RUN": "1"},  # Another way to run if no libfuse2 is available
 )
 
@@ -79,6 +88,10 @@ appimage(
         # Example: Compress the squashfs with zstd (gzip is usually the default).
         "-comp",
         "zstd",
+    ],
+    data = [
+        "appimage_data_file.txt",
+        ":appimage_data_filegroup",
     ],
 )
 

--- a/tests/appimage_data_file.txt
+++ b/tests/appimage_data_file.txt
@@ -1,0 +1,1 @@
+Hello world!

--- a/tests/appimage_data_filegroup.txt
+++ b/tests/appimage_data_filegroup.txt
@@ -1,0 +1,1 @@
+Hello from filegroup!

--- a/tests/test.py
+++ b/tests/test.py
@@ -17,12 +17,10 @@ def test_datadep() -> None:
     assert data_dep.is_file(), f"{data_dep} does not exist"
     assert (size := data_dep.stat().st_size) == 591, f"{data_dep} has wrong size {size}"
 
-    """Test that the data dependency to the appimage itself is bundled."""
     data_dep = Path("tests/appimage_data_file.txt")
     assert data_dep.is_file(), f"{data_dep} does not exist"
     assert (size := data_dep.stat().st_size) == 13, f"{data_dep} has wrong size {size}"
 
-    """Test that the data dependency to the appimage itself is bundled."""
     data_dep = Path("tests/appimage_data_filegroup.txt")
     assert data_dep.is_file(), f"{data_dep} does not exist"
     assert (size := data_dep.stat().st_size) == 22, f"{data_dep} has wrong size {size}"

--- a/tests/test.py
+++ b/tests/test.py
@@ -12,11 +12,14 @@ _ENV.update({"TMPDIR": _TMPDIR})
 
 
 def test_datadep() -> None:
-    """Test that the data dependency is bundled."""
+    """Test that the data dependency of the binary is bundled."""
     data_dep = Path("tests/data.txt")
     assert data_dep.is_file(), f"{data_dep} does not exist"
     assert (size := data_dep.stat().st_size) == 591, f"{data_dep} has wrong size {size}"
 
+
+def test_appimage_datadep() -> None:
+    """Test that data deps to the appimage itself are bundled."""
     data_dep = Path("tests/appimage_data_file.txt")
     assert data_dep.is_file(), f"{data_dep} does not exist"
     assert (size := data_dep.stat().st_size) == 13, f"{data_dep} has wrong size {size}"
@@ -95,6 +98,7 @@ def greeter() -> None:
 
 if __name__ == "__main__":
     test_datadep()
+    test_appimage_datadep()
     test_external_bin()
     test_symlinks()
     test_runfiles_symlinks()

--- a/tests/test.py
+++ b/tests/test.py
@@ -17,6 +17,16 @@ def test_datadep() -> None:
     assert data_dep.is_file(), f"{data_dep} does not exist"
     assert (size := data_dep.stat().st_size) == 591, f"{data_dep} has wrong size {size}"
 
+    """Test that the data dependency to the appimage itself is bundled."""
+    data_dep = Path("tests/appimage_data_file.txt")
+    assert data_dep.is_file(), f"{data_dep} does not exist"
+    assert (size := data_dep.stat().st_size) == 13, f"{data_dep} has wrong size {size}"
+
+    """Test that the data dependency to the appimage itself is bundled."""
+    data_dep = Path("tests/appimage_data_filegroup.txt")
+    assert data_dep.is_file(), f"{data_dep} does not exist"
+    assert (size := data_dep.stat().st_size) == 22, f"{data_dep} has wrong size {size}"
+
 
 def test_external_bin() -> None:
     """Test that the external binary is bundled."""


### PR DESCRIPTION
This allows adding custom data to an appimage. The use case is a setup in which one would normally use a `label_flag` option to add additional runfiles to a given executable. We want to encode some useful values of that `label_flag` in the appimage.