### PR TITLE
Switch to Bazel-built mksquashfs

### DIFF
--- a/appimage/private/tool/BUILD
+++ b/appimage/private/tool/BUILD
@@ -14,25 +14,12 @@ copy_file(
     is_executable = True,
 )
 
-copy_file(
-    name = "mksquashfs_copy",
-    src = select({
-        "@platforms//cpu:arm64": "@mksquashfs_aarch64//file",
-        "@platforms//cpu:armv7e-m": "@mksquashfs_armhf//file",
-        "@platforms//cpu:i386": "@mksquashfs_i686//file",
-        "@platforms//cpu:x86_64": "@mksquashfs_x86_64//file",
-    }),
-    out = "mksquashfs",
-    allow_symlink = True,
-    is_executable = True,
-)
-
 py_library(
     name = "mkappimage",
     srcs = ["mkappimage.py"],
     data = [
         ":appimage_runtime",
-        ":mksquashfs",
+        "@squashfs-tools//:mksquashfs",
     ],
     visibility = ["//visibility:public"],
     deps = ["@rules_python//python/runfiles"],

--- a/appimage/private/tool/mkappimage.py
+++ b/appimage/private/tool/mkappimage.py
@@ -12,7 +12,7 @@ from typing import Dict, Iterable, List, NamedTuple, Optional, Tuple
 from rules_python.python.runfiles import runfiles
 
 APPIMAGE_RUNTIME = Path(runfiles.Create().Rlocation("rules_appimage/appimage/private/tool/appimage_runtime"))
-MKSQUASHFS = Path(runfiles.Create().Rlocation("rules_appimage/appimage/private/tool/mksquashfs"))
+MKSQUASHFS = Path(runfiles.Create().Rlocation("squashfs-tools/mksquashfs"))
 
 
 class AppDirParams(NamedTuple):

--- a/deps.bzl
+++ b/deps.bzl
@@ -8,10 +8,6 @@ _SHAS = {
     "appimage_runtime_armhf": "dc6a546bd38a2df4cc6b14b0f2bcf925b0452e8a70d05b6027a631d60d26039b",
     "appimage_runtime_i686": "480017cfe6fa81785954c4ea39e4d06bc3b8fc287a55082ae781069c5d399116",
     "appimage_runtime_x86_64": "b86ac7572bb0b3ead120b09430a9dbeadde2f76ae54c1e30659cb54992d60ec1",
-    "mksquashfs_aarch64": "9cbe4cf6d6b83ac906cd4232192e532493285d2a499ebc31b6d7536957dcbf21",
-    "mksquashfs_armhf": "36e95cc77948cb74b1496ddcda3540b7265d734a022854434693a2fcd3c5bd32",
-    "mksquashfs_i686": "55f8a7f915bf2b526148d7ed393787f683db59b69e0a4ec4e5d6345d999ee0e2",
-    "mksquashfs_x86_64": "64a10d2f0dbd0c49753d10fef1afe615d4936794a942f40792f4fa3016199d6c",
 }
 
 def rules_appimage_deps():
@@ -26,6 +22,15 @@ def rules_appimage_deps():
         ],
     )
 
+    maybe(
+        http_archive,
+        name = "squashfs-tools",
+        build_file = "//third_party:squashfs-tools.BUILD",
+        sha256 = "94201754b36121a9f022a190c75f718441df15402df32c2b520ca331a107511c",
+        strip_prefix = "squashfs-tools-4.6.1/squashfs-tools",
+        url = "https://github.com/plougher/squashfs-tools/archive/refs/tags/4.6.1.tar.gz",
+    )
+
     for arch in ("aarch64", "armhf", "i686", "x86_64"):
         name = "appimage_runtime_" + arch
         maybe(
@@ -36,18 +41,19 @@ def rules_appimage_deps():
             urls = ["https://github.com/lalten/type2-runtime/releases/download/build-2022-10-03-c5c7b07/runtime-{}".format(arch)],
         )
 
-        name = "mksquashfs_" + arch
-        maybe(
-            http_file,
-            name = name,
-            executable = True,
-            sha256 = _SHAS[name],
-            urls = ["https://github.com/lalten/static-tools/releases/download/build-2022-10-02-970eff7/mksquashfs-{}".format(arch)],
-        )
-
     maybe(
         http_file,
         name = "appimagetool.png",
         sha256 = "0c23daaf7665216a8e8f9754c904ec18b2dfa376af2479601a571e504239fae6",
         urls = ["https://raw.githubusercontent.com/AppImage/AppImageKit/b51f685/resources/appimagetool.png"],
+    )
+
+    # zstd is a dep of squashfs-tools
+    maybe(
+        http_archive,
+        name = "zstd",
+        build_file = "//third_party:zstd.BUILD",
+        sha256 = "9c4396cc829cfae319a6e2615202e82aad41372073482fce286fac78646d3ee4",
+        strip_prefix = "zstd-1.5.5",
+        url = "https://github.com/facebook/zstd/releases/download/v1.5.5/zstd-1.5.5.tar.gz",
     )

--- a/tests/test_appimage.py
+++ b/tests/test_appimage.py
@@ -1,9 +1,9 @@
 """Test appimages as data deps."""
 
+import os
 import subprocess
 import sys
 from pathlib import Path
-import os
 
 import pytest
 

--- a/third_party/squashfs-tools.BUILD
+++ b/third_party/squashfs-tools.BUILD
@@ -1,0 +1,56 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
+cc_library(
+    name = "common",
+    srcs = glob(
+        [
+            "*.c",
+            "*.h",
+        ],
+        exclude = [
+            "mksquashfs.c",
+            "unsquash*",
+            "lz4*",
+            "lzma*",
+            "lzo*",
+            "xz*",
+        ],
+    ),
+    hdrs = ["squashfs_fs.h"],
+    defines = [
+        'COMP_DEFAULT=\\"gzip\\"',
+        'DATE=\\"redacted\\"',
+        'VERSION=\\"redacted\\"',
+        'YEAR=\\"redacted\\"',
+        "_FILE_OFFSET_BITS=64",
+        "_GNU_SOURCE",
+        "_LARGEFILE_SOURCE",
+        "GZIP_SUPPORT",
+        "REPRODUCIBLE_DEFAULT",
+        "XATTR_DEFAULT",
+        "XATTR_SUPPORT",
+        "ZSTD_SUPPORT",
+    ],
+    deps = [
+        "@bazel_tools//third_party/zlib",
+        "@zstd",
+    ],
+)
+
+cc_binary(
+    name = "mksquashfs",
+    srcs = [
+        "mksquashfs.c",
+        "mksquashfs.h",
+        "mksquashfs_error.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [":common"],
+)
+
+cc_binary(
+    name = "unsquashfs",
+    srcs = glob(["unsquash*"]),
+    visibility = ["//visibility:public"],
+    deps = [":common"],
+)

--- a/third_party/zstd.BUILD
+++ b/third_party/zstd.BUILD
@@ -1,0 +1,27 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "zstd",
+    srcs = glob([
+        "lib/common/*.c",
+        "lib/common/*.h",
+        "lib/compress/*.c",
+        "lib/compress/*.h",
+        "lib/decompress/*.c",
+        "lib/decompress/*.h",
+        "lib/decompress/*.S",
+        "lib/dictBuilder/*.c",
+        "lib/dictBuilder/*.h",
+    ]),
+    hdrs = [
+        "lib/zdict.h",
+        "lib/zstd.h",
+        "lib/zstd_errors.h",
+    ],
+    defines = [
+        "XXH_NAMESPACE=ZSTD_",
+        "ZSTD_MULTITHREAD",
+    ],
+    strip_include_prefix = "lib",
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
Having Bazel build `mksquashfs` from source should help with cross-target appimage building, which has mksquashfs running in exec configuration. With this setup, Bazel should do the right (:tm:) thing automatically. There is no need to pull in multiple mksquashfs static binaries.

Note that the mksquashfs we build here only supports gzip and zstd compressors. This is the same set as in the previous mksquashfs from https://github.com/lalten/static-tools/releases/tag/build-2022-10-02-f8b7a56

The zlib (for gzip) is taken directly from Bazel itself, so only zstd is a new external transitive source dependency.