### PR TITLE
use bazel-runfiles instead of accessing runfiles from rules_python

### DIFF
--- a/appimage/private/tool/BUILD
+++ b/appimage/private/tool/BUILD
@@ -1,12 +1,14 @@
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+load("@rules_appimage_py_deps//:requirements.bzl", "requirement")
+
 
 py_library(
     name = "mkappimage",
     srcs = ["mkappimage.py"],
     data = ["@squashfs-tools//:mksquashfs"],
     visibility = ["//visibility:public"],
-    deps = ["@rules_python//python/runfiles"],
-)
+    deps = [requirement("bazel-runfiles")],
+    )
 
 py_binary(
     name = "tool",

--- a/appimage/private/tool/BUILD
+++ b/appimage/private/tool/BUILD
@@ -1,6 +1,5 @@
-load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 load("@rules_appimage_py_deps//:requirements.bzl", "requirement")
-
+load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 
 py_library(
     name = "mkappimage",
@@ -8,7 +7,7 @@ py_library(
     data = ["@squashfs-tools//:mksquashfs"],
     visibility = ["//visibility:public"],
     deps = [requirement("bazel-runfiles")],
-    )
+)
 
 py_binary(
     name = "tool",

--- a/appimage/private/tool/mkappimage.py
+++ b/appimage/private/tool/mkappimage.py
@@ -9,12 +9,12 @@ import textwrap
 from pathlib import Path
 from typing import Dict, Iterable, List, NamedTuple, Optional, Tuple
 
-import rules_python.python.runfiles.runfiles
+import runfiles as bazel_runfiles
 
 
 def _get_path_or_raise(path: str) -> Path:
     """Return a Path to a file in the runfiles, or raise FileNotFoundError."""
-    runfiles = rules_python.python.runfiles.runfiles.Create()
+    runfiles = bazel_runfiles.Create()
     if not runfiles:
         raise FileNotFoundError("Could not find runfiles")
     runfile = runfiles.Rlocation(path)

--- a/requirements.in
+++ b/requirements.in
@@ -1,1 +1,2 @@
+bazel-runfiles==0.27.0
 pytest==7.4.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,9 @@
 #
 #    bazel run //:requirements.update
 #
+bazel-runfiles==0.27.0 \
+    --hash=sha256:ff2081001e27085a4c57bb828202603d3f3c349d3e9683c44aedf02836e8deab
+    # via -r requirements.in
 iniconfig==2.0.0 \
     --hash=sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3 \
     --hash=sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374


### PR DESCRIPTION
**What changed?**
The runfiles lib is being accessed as a pip dependency rather than as part of the rules_python.

**Why is this good?**
This change will hopefully allow rules_appimage to be usable from a WORKSPACE.bzlmod of a project with bzlmod enabled. I am not 100% sure about this theory, but there is no harm in this change IMO. As soon as this change is merged, I will try the new version and verify that rules_appimage works in a project when listed in a WORKSPACE.bzlmod