### PR TITLE
Silence compiler issues

### DIFF
--- a/tests/test.cc
+++ b/tests/test.cc
@@ -3,6 +3,8 @@
 #include <string>
 
 int main(int argc, char** argv, char** envp) {
+  (void)argc;
+  (void)argv;
   // Go through the environment variables and find the one we set in the BUILD.
   // When running inside the appimage, we want the env to not be lost.
   bool have_binary_env = false;

--- a/third_party/squashfs-tools.BUILD
+++ b/third_party/squashfs-tools.BUILD
@@ -17,6 +17,17 @@ cc_library(
         ],
     ),
     hdrs = ["squashfs_fs.h"],
+    copts = [
+        "-Wno-gnu-pointer-arith",
+        "-Wno-gnu-statement-expression-from-macro-expansion",
+        "-Wno-gnu-zero-variadic-macro-arguments",
+        "-Wno-missing-field-initializers",
+        "-Wno-pedantic",
+        "-Wno-sign-compare",
+        "-Wno-unused-parameter",
+        "-Wno-variadic-macros",
+        "-Wno-zero-length-array",
+    ],
     defines = [
         'COMP_DEFAULT=\\"gzip\\"',
         'DATE=\\"redacted\\"',


### PR DESCRIPTION
If the main repo's .bazelrc adds compiler flags to enable (more) warnings, this will hide them.