### PR TITLE
Mute `-Wunused-but-set-variable`

### DIFF
--- a/third_party/squashfs-tools.BUILD
+++ b/third_party/squashfs-tools.BUILD
@@ -24,6 +24,7 @@ cc_library(
         "-Wno-missing-field-initializers",
         "-Wno-pedantic",
         "-Wno-sign-compare",
+        "-Wno-unused-but-set-variable",
         "-Wno-unused-parameter",
         "-Wno-variadic-macros",
         "-Wno-zero-length-array",


### PR DESCRIPTION
```
INFO: From Compiling mksquashfs.c [for tool]:
external/squashfs-tools/mksquashfs.c:4919:6: warning: variable 'i' set but not used [-Wunused-but-set-variable]
        int i, res, first = TRUE, same = FALSE;
            ^
1 warning generated.
```