### PR TITLE
Add Bzlmod support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,13 +27,12 @@ jobs:
           restore-keys: bazel-${{ matrix.bazel-version }}-cache-
 
       - run: sed -i.bak '/enable_bzlmod/d' .bazelrc && rm .bazelrc.bak
-        if: ${{ startsWith(matrix.bazel-version, '5') }}
+        if: ${{ matrix.bazel-version == '5.x' }}
 
       - run: bazel test //...
 
-      - name: Run tests (bzlmod enabled)
+      - run: bazel test --enable_bzlmod //...
         if: ${{ matrix.bazel-version != '5.x' }}
-        run: bazel test --test_env=NO_CLEANUP=1 --enable_bzlmod //...
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,6 +31,10 @@ jobs:
 
       - run: bazel test //...
 
+      - name: Run tests (bzlmod enabled)
+        if: ${{ matrix.bazel-version != '5.x' }}
+        run: bazel test --test_env=NO_CLEANUP=1 --enable_bzlmod //...
+
   lint:
     runs-on: ubuntu-latest
     permissions:

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ bazel_dep(name = "aspect_rules_py", version = "0.4.0")
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
 bazel_dep(name = "platforms", version = "0.0.8")
 bazel_dep(name = "rules_cc", version = "0.0.9")
-bazel_dep(name = "rules_python", version = "0.26.0")
+bazel_dep(name = "rules_python", version = "0.27.1")
 
 rules_appimage = use_extension("//:extensions.bzl", "appimage_ext_dependencies")
 use_repo(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,33 @@
+module(
+    name = "rules_appimage",
+    version = "1.3.0",
+)
+
+bazel_dep(name = "aspect_rules_py", version = "0.4.0")
+bazel_dep(name = "bazel_skylib", version = "1.5.0")
+bazel_dep(name = "platforms", version = "0.0.8")
+bazel_dep(name = "rules_cc", version = "0.0.9")
+bazel_dep(name = "rules_python", version = "0.26.0")
+
+rules_appimage = use_extension("//:extensions.bzl", "appimage_ext_dependencies")
+use_repo(
+    rules_appimage,
+    "appimage_runtime_aarch64",
+    "appimage_runtime_i386",
+    "appimage_runtime_armv7e-m",
+    "appimage_runtime_x86_64",
+    "appimagetool.png",
+    "squashfs-tools",
+)
+
+register_toolchains("//appimage:all")
+
+python = use_extension("@rules_python//python/extensions:python.bzl", "python")
+python.toolchain(python_version = "3.11")
+pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
+pip.parse(
+    hub_name = "rules_appimage_py_deps",
+    python_version = "3.11",
+    requirements_lock = "//:requirements.txt",
+)
+use_repo(pip, "rules_appimage_py_deps")

--- a/extensions.bzl
+++ b/extensions.bzl
@@ -1,3 +1,5 @@
+"""rules_appimage bzlmod extensions."""
+
 load("//:deps.bzl", "rules_appimage_deps")
 
 def _appimage_ext_dependencies_impl(_):

--- a/extensions.bzl
+++ b/extensions.bzl
@@ -1,0 +1,6 @@
+load("//:deps.bzl", "rules_appimage_deps")
+
+def _appimage_ext_dependencies_impl(_):
+    rules_appimage_deps()
+
+appimage_ext_dependencies = module_extension(implementation = _appimage_ext_dependencies_impl)


### PR DESCRIPTION
There's an open PR to add Bzlmod support (https://github.com/lalten/rules_appimage/pull/78), but it hasn't landed and it's out of date.
This PR adds Bzlmod support for 1.3.0. I've tested it locally within the project and by pulling this in as a dependency from another workspace.