### PR TITLE
Support dangling symlinks created with `ctx.actions.declare_symlink`

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,6 +2,7 @@ build --color=yes
 build --cxxopt=-std=c++20
 build --incompatible_strict_action_env
 build --keep_going
+common --experimental_allow_unresolved_symlinks  # Only required for Bazel 5
 common --noenable_bzlmod  # This line is automatically removed in CI for Bazel 5
 test --announce_rc
 test --keep_going

--- a/appimage/private/tool/mkappimage.py
+++ b/appimage/private/tool/mkappimage.py
@@ -111,7 +111,15 @@ def populate_appdir(appdir: Path, params: AppDirParams) -> None:
 
     linkpairs: List[Tuple[Path, Path]] = []
     for file in manifest_data["files"]:
-        src = Path(file["src"]).resolve()
+        src = Path(file["src"])
+        src_actual = src.resolve()
+        if not src_actual.exists():
+            # src is declared as an input, but is a dangling symlink. Let's keep it as is.
+            pass
+        else:
+            # It's ok to resolve the file here as it's supposed to be an actual input file.
+            # Runfile symlinks are handled below.
+            src = src_actual
         dst = Path(appdir / file["dst"]).resolve()
         linkpairs.extend(copy_and_link(src, dst))
     fix_linkpair(linkpairs)

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -2,7 +2,7 @@ load("@rules_appimage_py_deps//:requirements.bzl", "requirement")
 load("@rules_cc//cc:defs.bzl", "cc_binary")
 load("@rules_python//python:defs.bzl", "py_binary", "py_test")
 load("//appimage:appimage.bzl", "appimage", "appimage_test")
-load(":testrules.bzl", "rules_appimage_test_rule")
+load(":testrules.bzl", "declared_symlink", "runfiles_symlink")
 
 sh_binary(
     name = "test_sh",
@@ -61,8 +61,10 @@ py_binary(
     data = [
         "data.txt",
         "dir",  # this is a relative directory, not a target label
+        ":absolutely_invalid_link",
         ":external_bin.appimage",
-        ":symlink_and_emptyfile",
+        ":path/to/the/runfiles_symlink",
+        ":relatively_invalid_link",
     ],
     env = {"MY_BINARY_ENV": "propagated only in Bazel 7+"},
     main = "test.py",
@@ -117,11 +119,6 @@ appimage(
     },
 )
 
-rules_appimage_test_rule(
-    name = "symlink_and_emptyfile",
-    symlink = "data.txt",
-)
-
 sh_test(
     name = "runfiles_test_sh",
     size = "small",
@@ -136,4 +133,19 @@ appimage_test(
     env = {"RUNFILES_LIB_DEBUG": "1"},
     tags = ["requires-fakeroot"],
     target_compatible_with = ["@platforms//os:linux"],
+)
+
+declared_symlink(
+    name = "relatively_invalid_link",
+    target = "././.././idonotexist",
+)
+
+declared_symlink(
+    name = "absolutely_invalid_link",
+    target = "/💣",
+)
+
+runfiles_symlink(
+    name = "path/to/the/runfiles_symlink",
+    target = ":data.txt",
 )

--- a/tests/dir/subdir/invalid_link
+++ b/tests/dir/subdir/invalid_link
@@ -1,1 +1,0 @@
-./invalid/target

--- a/tests/test.py
+++ b/tests/test.py
@@ -75,10 +75,6 @@ def test_symlinks() -> None:
 
 def test_declared_symlinks() -> None:
     """Test that symlinks declared via `ctx.actions.declare_symlink(...)` are handled correctly."""
-    if os.getenv("USE_BAZEL_VERSION", "latest").startswith("5."):
-        # It seems Bazel <6 does not support `declare_symlink`, even with --experimental_allow_unresolved_symlinks
-        return
-
     invalid_link = Path("tests/relatively_invalid_link")
     assert invalid_link.is_symlink()
     target = os.readlink(invalid_link)

--- a/tests/test_appimage.py
+++ b/tests/test_appimage.py
@@ -46,8 +46,11 @@ def test_symlinks() -> None:
     extracted_path = Path(_TMPDIR) / "squashfs-root"
     symlinks_present = False
     for file in extracted_path.glob("**/*"):
-        if file.is_symlink() and file.name != "invalid_link":
-            assert file.resolve().exists(), f"{file} resolves to {file.resolve()}, which does not exist!"
+        if file.is_symlink():
+            if file.name in {"relatively_invalid_link", "absolutely_invalid_link"}:
+                assert not file.resolve().exists(), f"{file} resolves to {file.resolve()}, which should not exist!"
+            else:
+                assert file.resolve().exists(), f"{file} resolves to {file.resolve()}, which does not exist!"
             symlinks_present = True
     assert symlinks_present
 

--- a/tests/testrules.bzl
+++ b/tests/testrules.bzl
@@ -22,7 +22,8 @@ def _declared_symlink_impl(ctx):
             repr(declared_symlink.path),
         ]),
     )
-    return [DefaultInfo(files = depset([declared_symlink]))]
+    runfiles = ctx.runfiles(files = [declared_symlink])
+    return [DefaultInfo(runfiles = runfiles)]
 
 declared_symlink = rule(
     implementation = _declared_symlink_impl,


### PR DESCRIPTION
Support dangling symlinks created with `ctx.actions.declare_symlink` and remove invalid_link tests that are not compativle with remote caching