### PR TITLE
Remove absolute symlink tests

### DIFF
--- a/tests/BUILD
+++ b/tests/BUILD
@@ -61,10 +61,9 @@ py_binary(
     data = [
         "data.txt",
         "dir",  # this is a relative directory, not a target label
-        ":absolutely_invalid_link",
+        ":dangling_symlink",
         ":external_bin.appimage",
         ":path/to/the/runfiles_symlink",
-        ":relatively_invalid_link",
     ],
     env = {"MY_BINARY_ENV": "propagated only in Bazel 7+"},
     main = "test.py",
@@ -136,13 +135,8 @@ appimage_test(
 )
 
 declared_symlink(
-    name = "relatively_invalid_link",
+    name = "dangling_symlink",
     target = "././.././idonotexist",
-)
-
-declared_symlink(
-    name = "absolutely_invalid_link",
-    target = "/💣",
 )
 
 runfiles_symlink(

--- a/tests/test.py
+++ b/tests/test.py
@@ -75,16 +75,10 @@ def test_symlinks() -> None:
 
 def test_declared_symlinks() -> None:
     """Test that symlinks declared via `ctx.actions.declare_symlink(...)` are handled correctly."""
-    invalid_link = Path("tests/relatively_invalid_link")
+    invalid_link = Path("tests/dangling_symlink")
     assert invalid_link.is_symlink()
     target = os.readlink(invalid_link)
     assert target == "../idonotexist", target
-    assert not invalid_link.is_file()
-
-    invalid_link = Path("tests/absolutely_invalid_link")
-    assert invalid_link.is_symlink()
-    target = os.readlink(invalid_link)
-    assert target == "/💣", target
     assert not invalid_link.is_file()
 
 

--- a/tests/test_appimage.py
+++ b/tests/test_appimage.py
@@ -47,7 +47,7 @@ def test_symlinks() -> None:
     symlinks_present = False
     for file in extracted_path.glob("**/*"):
         if file.is_symlink():
-            if file.name in {"relatively_invalid_link", "absolutely_invalid_link"}:
+            if file.name == "dangling_symlink":
                 assert not file.resolve().exists(), f"{file} resolves to {file.resolve()}, which should not exist!"
             else:
                 assert file.resolve().exists(), f"{file} resolves to {file.resolve()}, which does not exist!"


### PR DESCRIPTION
Not all remote cache implementations actually support this. See https://cs.opensource.google/bazel/bazel/+/release-7.0.1:src/main/java/com/google/devtools/build/lib/remote/UploadManifest.java;l=212