### PR TITLE
Change symlink following behavior

### DIFF
--- a/appimage/private/runfiles.bzl
+++ b/appimage/private/runfiles.bzl
@@ -34,6 +34,9 @@ def _reference_dir(ctx):
     """The directory relative to which all ".short_path" paths are relative.
 
     For @foo//bar/baz:blah this would translate to /app/bar/baz/blah.runfiles/foo
+
+    If --enable_bzlmod is on, ctx.workspace_name is the fixed string _main.
+    Otherwise, ctx.workspace_name is the workspace name as defined in the WORKSPACE file.
     """
     return "/".join([_runfiles_dir(ctx), ctx.workspace_name])
 

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -62,6 +62,8 @@ py_binary(
         "data.txt",
         "dir",  # this is a relative directory, not a target label
         ":dangling_symlink",
+        ":dot_symlink",
+        ":dotdot_symlink",
         ":external_bin.appimage",
         ":path/to/the/runfiles_symlink",
     ],
@@ -138,6 +140,16 @@ appimage_test(
 declared_symlink(
     name = "dangling_symlink",
     target = "././.././idonotexist",
+)
+
+declared_symlink(
+    name = "dot_symlink",
+    target = ".",
+)
+
+declared_symlink(
+    name = "dotdot_symlink",
+    target = "..",
 )
 
 runfiles_symlink(

--- a/tests/test.py
+++ b/tests/test.py
@@ -2,6 +2,7 @@
 
 import argparse
 import os
+import re
 import subprocess
 from pathlib import Path
 
@@ -80,7 +81,7 @@ def test_symlinks() -> None:
     # "rules_appimage_python_x86_64-unknown-linux-gnu/bin/python3"
     # "rules_python~0.27.1~python~python_3_11_x86_64-unknown-linux-gnu/bin/python3"
     assert link.is_symlink()
-    assert os.readlink(link) == "python3.11"
+    assert re.match(r"^python3.\d+$", os.readlink(link)), os.readlink(link)
 
 
 def test_declared_symlinks() -> None:

--- a/tests/test.py
+++ b/tests/test.py
@@ -75,6 +75,13 @@ def test_symlinks() -> None:
     assert os.readlink(dir_link) == "dir"
     assert dir_link.resolve().is_dir()
 
+    link = next(Path("..").glob("**/bin/python3"))
+    # link will be one of these depending on --enable_bzlmod (and rules_python version)
+    # "rules_appimage_python_x86_64-unknown-linux-gnu/bin/python3"
+    # "rules_python~0.27.1~python~python_3_11_x86_64-unknown-linux-gnu/bin/python3"
+    assert link.is_symlink()
+    assert os.readlink(link) == "python3.11"
+
 
 def test_declared_symlinks() -> None:
     """Test that symlinks declared via `ctx.actions.declare_symlink(...)` are handled correctly."""

--- a/tests/test_appimage.py
+++ b/tests/test_appimage.py
@@ -45,9 +45,10 @@ def test_symlinks() -> None:
     subprocess.run(cmd, check=True, text=True, stdout=subprocess.PIPE, cwd=_TMPDIR, env=_ENV)
     extracted_path = Path(_TMPDIR) / "squashfs-root"
     symlinks_present = False
+    expected_dangling = {"dangling_symlink", "link_to_file_in_dir2", "link_to_link_to_file_in_dir2"}
     for file in extracted_path.glob("**/*"):
         if file.is_symlink():
-            if file.name == "dangling_symlink":
+            if file.name in expected_dangling:
                 assert not file.resolve().exists(), f"{file} resolves to {file.resolve()}, which should not exist!"
             else:
                 assert file.resolve().exists(), f"{file} resolves to {file.resolve()}, which does not exist!"


### PR DESCRIPTION
This PR changes how symlink runfiles are handled in appimages.

The effect of this can be seen by mounting an AppImage and running `tree` on the mounted dir:
```
❯ bazel run //tests:appimage_py -- --appimage-mount
/tmp/.mount_appimaHmeNGb
❯ tree /tmp/.mount_appimaHmeNGb
```

| Current `main` | `main` with BUILD changes from this PR (added `dot_symlink` and `dotdot_symlink`) | This PR |
|--------|--------|--------|
| ![image](https://github.com/lalten/rules_appimage/assets/11611719/05fa305f-ba9f-4458-9ec6-c188de331c48) | ![image](https://github.com/lalten/rules_appimage/assets/11611719/cadecec4-aeff-49a0-80de-7989380dbac0) | ![image](https://github.com/lalten/rules_appimage/assets/11611719/c5b2729c-575a-458a-b811-00af668bad81) | 

Before:
* Symlinks are followed, and (if found) the link target is made available, even if it is not declared as a data dep
* Symlinks that appear in `DefaultInfo.default_runfiles.files` are first resolved and then copied (but on the first level only), leading to directory duplication for `.` and `..` symlinks.
* This can also be seen in the Python toolchain binary symlinks (e.g. `python3`, `2to3`) are _copied_ multiple times instead of symlinked to their targets (`python3.11`, `2to3-3.11`)

After:
* Symlinks are _not_ followed, `.` and `..` link files are preserved.
  * Note that this causes files that are not part of the input depset to not be available. Arguably this behavior was more bug than feature.
  * You can see that the `../dir2` symlinks now become broken (and tests have been changed to reflect this). This is correct because `tests/dir2` is not part of the inputs (only `tests/dir` and `tests/dir/subdir` are)
* Using a simple heuristic, symlinks files that appear to be inside the Bazel cache are followed once before their target is evaluated. This allows Python tools have their symlinks preserved.

