### PR TITLE
Downgrade WORKSPACE rules_python to make Bazel 5 CI green

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -64,7 +64,7 @@ def rules_appimage_deps():
     maybe(
         http_archive,
         name = "rules_python",
-        sha256 = "d71d2c67e0bce986e1c5a7731b4693226867c45bfe0b7c5e0067228a536fc580",
-        strip_prefix = "rules_python-0.29.0",
-        url = "https://github.com/bazelbuild/rules_python/releases/download/0.29.0/rules_python-0.29.0.tar.gz",
+        sha256 = "e85ae30de33625a63eca7fc40a94fea845e641888e52f32b6beea91e8b1b2793",
+        strip_prefix = "rules_python-0.27.1",
+        url = "https://github.com/bazelbuild/rules_python/releases/download/0.27.1/rules_python-0.27.1.tar.gz",
     )


### PR DESCRIPTION
rules_python have dropped support for Bazel 5: https://github.com/bazelbuild/rules_python/pull/1613
This PR will downgrade rules_python to make the Bazel 5 CI matrix job green.
I'll make a new release after this lands, which will be the last Bazel 5 compatible version of rules_appimage.