### PR TITLE
Prepare release

### DIFF
--- a/.bcr/patches/old-gcc-std20.patch
+++ b/.bcr/patches/old-gcc-std20.patch
@@ -1,0 +1,11 @@
+diff --git a/.bazelrc b/.bazelrc
+index c1cf743..6263144 100644
+--- a/.bazelrc
++++ b/.bazelrc
+@@ -1,5 +1,5 @@
+ build --color=yes
+-build --cxxopt=-std=c++20
++build --cxxopt=-std=c++2a
+ build --incompatible_strict_action_env
+ build --keep_going
+ common --experimental_allow_unresolved_symlinks  # Only required for Bazel 5

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,9 +1,6 @@
 """AppImage rules for Bazel."""
 
-module(
-    name = "rules_appimage",
-    version = "1.6.0",
-)
+module(name = "rules_appimage")
 
 bazel_dep(name = "bazel_skylib", version = "1.5.0", dev_dependency = True)
 bazel_dep(name = "platforms", version = "0.0.8")


### PR DESCRIPTION
* Add the patch file that was manually added for the first BCR release
* Remove MODULE.bazel stamping to have the publish-to-bcr bot autogenerate a patch with the right version. See https://github.com/bazel-contrib/publish-to-bcr/blob/e765a5054ffa69f7c6950b568d2020fd1bfaf653/src/domain/create-entry.ts#L222-L225