### PR TITLE
Add back in module version

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 """AppImage rules for Bazel."""
 
-module(name = "rules_appimage")
+module(name = "rules_appimage", version = "0.0.0")
 
 bazel_dep(name = "bazel_skylib", version = "1.5.0", dev_dependency = True)
 bazel_dep(name = "platforms", version = "0.0.8")


### PR DESCRIPTION
I'm suspecting https://github.com/bazel-contrib/publish-to-bcr/issues/95 is why publish-to-bcr-bot doesn't do its thing