### PR TITLE
Add bazel test matrix for BCR presubmit tests

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -2,8 +2,10 @@ bcr_test_module:
   module_path: ""
   matrix:
     platform: [macos, ubuntu2004]
+    bazel: [6.x, 7.x]
   tasks:
     run_tests:
       name: Run tests
       platform: ${{ platform }}
+      bazel: ${{ bazel }}
       test_targets: [//...]


### PR DESCRIPTION
Comply with future enforcement of https://github.com/bazelbuild/bazel-central-registry/pull/1387