### PR TITLE
Use BCR squashfs when using Bzmlod

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,6 +6,7 @@ bazel_dep(name = "bazel_skylib", version = "1.5.0", dev_dependency = True)
 bazel_dep(name = "platforms", version = "0.0.8")
 bazel_dep(name = "rules_cc", version = "0.0.9")
 bazel_dep(name = "rules_python", version = "0.29.0")
+bazel_dep(name = "squashfs-tools", version = "4.6.1")
 bazel_dep(name = "zstd", version = "1.5.5.bcr.1")
 
 rules_appimage = use_extension("//:extensions.bzl", "appimage_ext_dependencies")
@@ -16,7 +17,6 @@ use_repo(
     "appimage_runtime_armv7e-m",
     "appimage_runtime_x86_64",
     "appimagetool.png",
-    "squashfs-tools",
 )
 
 register_toolchains("//appimage:all")

--- a/deps.bzl
+++ b/deps.bzl
@@ -13,21 +13,12 @@ RUNTIME_SHAS = {
 }
 
 def rules_appimage_deps():
-    """Declare http_archive deps needed for in the WORKSPACE version of rules_appimage."""
+    """Declare http_archive deps needed in the WORKSPACE version of rules_appimage."""
     rules_appimage_common_deps()
     _rules_appimage_workspace_deps()
 
 def rules_appimage_common_deps():
     """Declare http_archive deps needed for both the WORKSPACE and Bzlmod version of rules_appimage."""
-    maybe(
-        http_archive,
-        name = "squashfs-tools",
-        build_file = "@rules_appimage//third_party:squashfs-tools.BUILD",
-        sha256 = "94201754b36121a9f022a190c75f718441df15402df32c2b520ca331a107511c",
-        strip_prefix = "squashfs-tools-4.6.1/squashfs-tools",
-        url = "https://github.com/plougher/squashfs-tools/archive/refs/tags/4.6.1.tar.gz",
-    )
-
     for arch, runtime_arch in ARCHS.items():
         maybe(
             http_file,
@@ -54,6 +45,15 @@ def _rules_appimage_workspace_deps():
             "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.5.0/bazel-skylib-1.5.0.tar.gz",
             "https://github.com/bazelbuild/bazel-skylib/releases/download/1.5.0/bazel-skylib-1.5.0.tar.gz",
         ],
+    )
+
+    maybe(
+        http_archive,
+        name = "squashfs-tools",
+        build_file = "@rules_appimage//third_party:squashfs-tools.BUILD",
+        sha256 = "94201754b36121a9f022a190c75f718441df15402df32c2b520ca331a107511c",
+        strip_prefix = "squashfs-tools-4.6.1/squashfs-tools",
+        url = "https://github.com/plougher/squashfs-tools/archive/refs/tags/4.6.1.tar.gz",
     )
 
     # zstd is a dep of squashfs-tools


### PR DESCRIPTION
With https://github.com/bazelbuild/bazel-central-registry/pull/1406 landed, depend on BCR mksquashfs