### PR TITLE
Move the `-std=c++20` option to the BUILD target

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,7 +1,6 @@
 build --bes_backend=grpcs://remote.buildbuddy.io
 build --bes_results_url=https://app.buildbuddy.io/invocation/
 build --color=yes
-build --cxxopt=-std=c++20
 build --incompatible_strict_action_env
 build --keep_going
 build --remote_cache=grpcs://remote.buildbuddy.io

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -33,6 +33,7 @@ appimage_test(
 cc_binary(
     name = "test_cc",
     srcs = ["test.cc"],
+    copts = ["-std=c++20"],
     env = {
         "MY_APPIMAGE_ENV": "original",
         "MY_BINARY_ENV": "not lost",


### PR DESCRIPTION
The .bazelrc was not read in BCR with the `bcr_test_module` root key in the presubmit.yaml removed.