### PR TITLE
Reinstate `bcr_test_module` root key in presubmit.yml

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,8 +1,10 @@
-matrix:
-  platform: [macos, ubuntu2204]
-  bazel: [6.x, 7.x]
-tasks:
-  run_tests:
-    platform: ${{ platform }}
-    bazel: ${{ bazel }}
-    test_targets: [//...]
+bcr_test_module:
+  module_path: ""
+  matrix:
+    platform: [macos, ubuntu2204]
+    bazel: [6.x, 7.x]
+  tasks:
+    run_tests:
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets: [//...]


### PR DESCRIPTION
It was causing behavior changes breaking the build in BCR CI. See https://github.com/bazelbuild/bazel-central-registry/pull/1488#issuecomment-1986860002