### PR TITLE
Set `BUILD_WORKING_DIRECTORY` even when `APPIMAGE_EXTRACT_AND_RUN=1`

### DIFF
--- a/appimage/private/tool/mkappimage.py
+++ b/appimage/private/tool/mkappimage.py
@@ -164,6 +164,53 @@ def _move_relative_symlinks_in_files_to_their_own_section(manifest_data: _Manife
     return new_manifest_data
 
 
+def _make_apprun_content(params: AppDirParams) -> str:
+    """Generate the AppRun, which is the AppImage's entrypoint."""
+    # A shebang with `/bin/sh` does not mean a specific shell but any POSIX standard compliant shell.
+    apprun_lines = ["#!/bin/sh"]
+
+    # Set up the previously `export -p`ed environment.
+    # This sets up any environment variables coming from the `env` attribute on the appimage target.
+    apprun_lines.extend(params.envfile.read_text().splitlines())
+
+    # The generated AppImage must be able to run outside of Bazel. We conveniently set BUILD_WORKING_DIRECTORY in the
+    # to the same value that it would have if the code would be run under `bazel run`. This is important for calculating
+    # the actual location of relative paths passed in as user input on command line arguments.
+    # We set BUILD_WORKING_DIRECTORY to the first set and not empty value of [BUILD_WORKING_DIRECTORY, OWD, PWD].
+    # * $BUILD_WORKING_DIRECTORY (see https://bazel.build/docs/user-manual#running-executables) is set by Bazel in
+    #   https://github.com/bazelbuild/bazel/blob/7.1.1/src/main/java/com/google/devtools/build/lib/runtime/commands/RunCommand.java#L548
+    #   and is only available when Bazel executes the AppImage for us during bazel run (but not test/coverage).
+    # * $OWD ("Original Working Directory") is set by the AppImage runtime in
+    #   https://github.com/lalten/type2-runtime/blob/84f7a00/src/runtime/runtime.c#L1757.
+    #   When the AppImage is mounted with libfuse its working directory is inside the mount point, which is not the
+    #   original working directory of the user. Presumably this is why the AppImage runtime sets OWD only when mounted
+    #   with libfuse but *not* when running with APPIMAGE_EXTRACT_AND_RUN=1 or --appimage-extract-and-run. See
+    #   https://github.com/AppImage/type2-runtime/issues/23).
+    # * $PWD is set by the shell to the current working directory. This is correct if and only if we are not running
+    #   under Bazel and not mounted with libfuse, so it is a good value to use as a fallback. It's important to store
+    #   $PWD to $BUILD_WORKING_DIRECTORY because we change the working directory to the $RUNFILES_DIR below. This means
+    #   that at runtime, $PWD is different to the directory that the user ran the appimage from.
+    # This is done with POSIX shell command language ${parameter:-word} "Use Default Values" parameter expansion, see
+    # https://pubs.opengroup.org/onlinepubs/009695399/utilities/xcu_chap02.html#tag_02_06_02
+    # Note that BUILD_WORKING_DIRECTORY's sibling BUILD_WORKSPACE_DIRECTORY is not of much use here as even if we knew
+    # it at build time, it's not guaranteed to be correct or available at runtime.
+    apprun_lines.append('OWD="${OWD=$PWD}"')  # remove when https://github.com/AppImage/type2-runtime/issues/23 is fixed
+    apprun_lines.append('BUILD_WORKING_DIRECTORY="${BUILD_WORKING_DIRECTORY=$OWD}"')
+    apprun_lines.append("export BUILD_WORKING_DIRECTORY")
+
+    # Explicitly set RUNFILES_DIR to the runfiles dir of the binary instead of the appimage rule itself
+    apprun_lines.append(f'workdir="$(dirname "$0")/{params.workdir}"')
+    apprun_lines.append('RUNFILES_DIR="$(dirname "$workdir")"')
+    apprun_lines.append("export RUNFILES_DIR")
+    # Run under runfiles
+    apprun_lines.append('cd "$workdir"')
+
+    # Launch the actual binary
+    apprun_lines.append(f'exec "./{params.entrypoint}" "$@"')
+
+    return "\n".join(apprun_lines) + "\n"
+
+
 def populate_appdir(appdir: Path, params: AppDirParams) -> None:
     """Make the AppDir that will be squashfs'd into the AppImage."""
     appdir.mkdir(parents=True, exist_ok=True)
@@ -208,28 +255,7 @@ def populate_appdir(appdir: Path, params: AppDirParams) -> None:
         linkfile.symlink_to(target)
 
     apprun_path = appdir / "AppRun"
-    apprun_path.write_text(
-        "\n".join(
-            [
-                "#!/bin/sh",
-                # Set up the previously `export -p`ed environment
-                *params.envfile.read_text().splitlines(),
-                # If running as AppImage outside Bazel, conveniently set BUILD_WORKING_DIRECTORY, like `bazel run` would
-                # `$OWD` ("Original Working Directory") is set by the AppImage runtime in
-                # https://github.com/lalten/type2-runtime/blob/84f7a00/src/runtime/runtime.c#L1757
-                # Note that we can not set BUILD_WORKSPACE_DIRECTORY as it's not known when the AppImage is deployed
-                '[ "${BUILD_WORKING_DIRECTORY+1}" ] || export BUILD_WORKING_DIRECTORY="$OWD"',
-                # Explicitly set RUNFILES_DIR to the runfiles dir of the binary instead of the appimage rule itself
-                f'workdir="$(dirname $0)/{params.workdir}"',
-                'export RUNFILES_DIR="$(dirname "${workdir}")"',
-                # Run under runfiles
-                'cd "${workdir}"',
-                # Launch the actual binary
-                f'exec "./{params.entrypoint}" "$@"',
-            ],
-        )
-        + "\n",
-    )
+    apprun_path.write_text(_make_apprun_content(params))
     apprun_path.chmod(0o751)
 
     apprun_path.with_suffix(".desktop").write_text(

--- a/tests/build_working_directory/BUILD
+++ b/tests/build_working_directory/BUILD
@@ -16,4 +16,5 @@ sh_test(
     srcs = ["test.sh"],
     data = [":test.appimage"],
     tags = ["requires-fakeroot"],
+    target_compatible_with = ["@platforms//os:linux"],
 )

--- a/tests/build_working_directory/BUILD
+++ b/tests/build_working_directory/BUILD
@@ -1,0 +1,19 @@
+load("@rules_appimage//appimage:appimage.bzl", "appimage")
+
+sh_binary(
+    name = "entrypoint",
+    srcs = ["entrypoint.sh"],
+)
+
+appimage(
+    name = "test.appimage",
+    binary = ":entrypoint",
+)
+
+sh_test(
+    name = "test",
+    timeout = "short",
+    srcs = ["test.sh"],
+    data = [":test.appimage"],
+    tags = ["requires-fakeroot"],
+)

--- a/tests/build_working_directory/entrypoint.sh
+++ b/tests/build_working_directory/entrypoint.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+env | sort

--- a/tests/build_working_directory/test.sh
+++ b/tests/build_working_directory/test.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -euxo pipefail
+
+actual_wd="$(pwd)"
+
+# BUILD_WORKING_DIRECTORY is not set when running the appimage directly
+unset BUILD_WORKING_DIRECTORY
+
+# BUILD_WORKING_DIRECTORY is set inside the appimage when libfuse-mounted
+env="$(env -i -- PATH="/bin" tests/build_working_directory/test.appimage)"
+grep -q OWD= <<<"$env"
+bwd="$(grep BUILD_WORKING_DIRECTORY= <<<"$env" | cut -d= -f2-)"
+[ "$bwd" = "$actual_wd" ]
+
+# BUILD_WORKING_DIRECTORY is set inside the appimage when using APPIMAGE_EXTRACT_AND_RUN
+env="$(env -i -- PATH="/bin" APPIMAGE_EXTRACT_AND_RUN=1 tests/build_working_directory/test.appimage)"
+grep -q OWD= <<<"$env" && exit 1 # https://github.com/AppImage/type2-runtime/issues/23
+bwd="$(grep BUILD_WORKING_DIRECTORY= <<<"$env" | cut -d= -f2-)"
+[ "$bwd" = "$actual_wd" ]


### PR DESCRIPTION
This PR reworks the AppRun entrypoint generation a bit. Major changes are:
* Don't re-export some build context environment vars to the AppRun script
* Fall back to using `$PWD` (which is now correct and not the build time PWD anymore) for `BUILD_WORKING_DIRECTORY` if neither `$BUILD_WORKING_DIRECTORY` nor `$OWD` is available due to https://github.com/AppImage/type2-runtime/issues/23

Closes https://github.com/lalten/rules_appimage/issues/156