### PR TITLE
Remove icon support

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -16,7 +16,6 @@ use_repo(
     "appimage_runtime_i386",
     "appimage_runtime_armv7e-m",
     "appimage_runtime_x86_64",
-    "appimagetool.png",
 )
 
 register_toolchains("//appimage:all")

--- a/appimage/appimage.bzl
+++ b/appimage/appimage.bzl
@@ -15,13 +15,12 @@ def _appimage_impl(ctx):
     manifest_file = ctx.actions.declare_file(ctx.attr.name + "-manifest.json")
     ctx.actions.write(manifest_file, json.encode_indent(runfile_info.manifest))
     apprun = make_apprun(ctx)
-    inputs = depset(direct = [ctx.file.icon, manifest_file, apprun, toolchain.appimage_runtime] + runfile_info.files)
+    inputs = depset(direct = [manifest_file, apprun, toolchain.appimage_runtime] + runfile_info.files)
 
     # TODO: Use Skylib's shell.quote?
     args = [
         "--manifest={}".format(manifest_file.path),
         "--apprun={}".format(apprun.path),
-        "--icon={}".format(ctx.file.icon.path),
         "--runtime={}".format(toolchain.appimage_runtime.path),
     ]
     args.extend(["--mksquashfs_arg=" + arg for arg in ctx.attr.build_args])
@@ -59,7 +58,6 @@ _ATTRS = {
     "build_env": attr.string_dict(),
     "data": attr.label_list(allow_files = True, doc = "Any additional data that will be made available inside the appimage"),
     "env": attr.string_dict(doc = "Runtime environment variables. See https://bazel.build/reference/be/common-definitions#common-attributes-tests"),
-    "icon": attr.label(default = "@appimagetool.png//file", allow_single_file = True),
     "_tool": attr.label(default = "//appimage/private/tool", executable = True, cfg = "exec"),
 }
 

--- a/appimage/private/tool/cli.py
+++ b/appimage/private/tool/cli.py
@@ -25,12 +25,6 @@ def parse_args(args: Sequence[str] | None = None) -> argparse.Namespace:
         help="Path to AppRun script",
     )
     parser.add_argument(
-        "--icon",
-        required=True,
-        type=Path,
-        help="Icon to use in the AppImage, e.g. 'external/AppImageKit/resources/appimagetool.png'",
-    )
-    parser.add_argument(
         "--mksquashfs_arg",
         required=False,
         action="append",
@@ -52,7 +46,6 @@ def cli(args: Sequence[str] | None = None) -> None:
     appdir_params = AppDirParams(
         parsed_args.manifest,
         parsed_args.apprun,
-        parsed_args.icon,
         parsed_args.runtime,
     )
     make_appimage(appdir_params, parsed_args.mksquashfs_arg or [], parsed_args.output)

--- a/deps.bzl
+++ b/deps.bzl
@@ -28,13 +28,6 @@ def rules_appimage_common_deps():
             urls = ["https://github.com/lalten/type2-runtime/releases/download/build-2022-10-03-c5c7b07/runtime-{}".format(runtime_arch)],
         )
 
-    maybe(
-        http_file,
-        name = "appimagetool.png",
-        sha256 = "0c23daaf7665216a8e8f9754c904ec18b2dfa376af2479601a571e504239fae6",
-        urls = ["https://raw.githubusercontent.com/AppImage/AppImageKit/b51f685/resources/appimagetool.png"],
-    )
-
 def _rules_appimage_workspace_deps():
     """Declare http_archive deps only needed in the WORKSPACE version of rules_appimage."""
     maybe(

--- a/tests/tool/tests/test_cli.py
+++ b/tests/tool/tests/test_cli.py
@@ -19,8 +19,6 @@ def test_cli() -> None:
             "AppRun.sh",
             "--runtime",
             "runtime",
-            "--icon",
-            "icon",
             "--mksquashfs_arg=-mem",
             "--mksquashfs_arg=500M",
             "output",
@@ -30,7 +28,6 @@ def test_cli() -> None:
         manifest=Path("manifest.json"),
         apprun=Path("AppRun.sh"),
         runtime=Path("runtime"),
-        icon=Path("icon"),
         mksquashfs_arg=["-mem", "500M"],
         output=Path("output"),
     )

--- a/tests/tool/tests/test_mkappimage.py
+++ b/tests/tool/tests/test_mkappimage.py
@@ -38,7 +38,7 @@ def fake_make_squashfs(_params: mkappimage.AppDirParams, _mksquashfs_params: Ite
 def test_make_appimage_native() -> None:
     """Test that the AppImage is created by concatenating the native runtime and the squashfs."""
     runtime_path = mkappimage._get_path_or_raise("rules_appimage/tests/tool/tests/appimage_runtime_native")
-    params = mkappimage.AppDirParams(Path(), Path(), Path(), Path(runtime_path))
+    params = mkappimage.AppDirParams(Path(), Path(), Path(runtime_path))
     mkappimage.make_appimage(params, [], Path("fake.appimage"))
     appimage = Path("fake.appimage").read_bytes()
     assert appimage.startswith(runtime_path.read_bytes())


### PR DESCRIPTION
The [AppImage Type2 Spec][appimage-spec] specifies that the contained [AppDir][appdir-spec] may contain a  [.desktop file][desktop-spec]. To my knowledge this is only used with [appimaged][appimaged] and entirely optional.

The only reason for very basic icon file support to exist in rules_appimage is that the first implementation used [appimagetool][appimagetool] to build appimages, which makes using an icon file mandatory.

I don't know of anyone who actually used this feature. Dropping this feature is long overdue and should slightly speed up builds as well as produce smaller appimage artifacts because we don't need to copy, compress, and store the png file.

[appdir-spec]: https://rox.sourceforge.net/desktop/AppDirs.html
[appimage-spec]: https://github.com/AppImage/AppImageSpec/blob/master/draft.md
[desktop-spec]: https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html
[appimaged]: https://docs.appimage.org/user-guide/run-appimages.html#integrating-appimages-into-the-desktop
[appimagetool]: https://github.com/AppImage/appimagetool