### PR TITLE
Correct `copy_file_or_dir` behavior for dangling symlinks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,3 +50,4 @@ repos:
   rev: v1.11.1
   hooks:
   - id: mypy
+    additional_dependencies: [click, pytest]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,7 @@ repos:
   rev: 1.16.0
   hooks:
   - id: yamlfix
+    additional_dependencies: [maison]
 - repo: https://github.com/koalaman/shellcheck-precommit
   rev: v0.10.0
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,11 +20,11 @@ repos:
   - id: ruff
     args: [--fix, --unsafe-fixes]
   - id: ruff-format
-- repo: https://github.com/lyz-code/yamlfix
-  rev: 1.16.0
-  hooks:
-  - id: yamlfix
-    additional_dependencies: [maison]
+# TODO: fix "ModuleNotFoundError: No module named 'maison.schema'"
+# - repo: https://github.com/lyz-code/yamlfix
+#   rev: 1.16.0
+#   hooks:
+#   - id: yamlfix
 - repo: https://github.com/koalaman/shellcheck-precommit
   rev: v0.10.0
   hooks:

--- a/appimage/private/mkappdir.py
+++ b/appimage/private/mkappdir.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import argparse
 import copy
-import errno
 import functools
 import json
 import os
@@ -74,7 +73,7 @@ def is_inside_bazel_cache(path: Path) -> bool:
     return os.fspath(path).startswith(get_output_base())
 
 
-def copy_file_or_dir(src: Path, dst: Path, preserve_symlinks: bool) -> Path:
+def copy_file_or_dir(src: Path, dst: Path, preserve_symlinks: bool) -> None:
     """Copy a file or dir from src to dst.
 
     We use copy2 because it preserves metadata like permissions.
@@ -83,7 +82,8 @@ def copy_file_or_dir(src: Path, dst: Path, preserve_symlinks: bool) -> Path:
     """
     dst.parent.mkdir(parents=True, exist_ok=True)
     if not src.is_dir():
-        return shutil.copy2(src, dst, follow_symlinks=not preserve_symlinks)
+        shutil.copy2(src, dst, follow_symlinks=not preserve_symlinks)
+        return
 
     # Scan and recreate dangling symlinks
     dangling: set[Path] = set()
@@ -96,7 +96,7 @@ def copy_file_or_dir(src: Path, dst: Path, preserve_symlinks: bool) -> Path:
         dangling.add(link)
 
     copy_function = functools.partial(shutil.copy2, follow_symlinks=not preserve_symlinks)
-    return shutil.copytree(
+    shutil.copytree(
         src,
         dst,
         symlinks=preserve_symlinks,

--- a/examples/hello.py
+++ b/examples/hello.py
@@ -7,7 +7,7 @@ import click
 DATA_FILE = Path("resources/data.txt")
 
 
-@click.command()  # type: ignore [misc]
+@click.command()
 def main() -> None:
     """Print "Hello, world!" to the console."""
     data = DATA_FILE.read_text().strip()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ select = [
   "PERF",
   "RUF",
 ]
-ignore = ["COM812", "D203", "D213", "PLR2004", "TRY003"]
+ignore = ["COM812", "D103", "D203", "D213", "PLR2004", "TRY003"]
 
 [tool.ruff]
 line-length = 120

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -176,3 +176,13 @@ runfiles_symlink(
     name = "path/to/the/runfiles_symlink",
     target = ":data.txt",
 )
+
+py_test(
+    name = "mkappdir_test",
+    size = "small",
+    srcs = ["mkappdir_test.py"],
+    deps = [
+        "//appimage/private:mkappdir",
+        requirement("pytest"),
+    ],
+)

--- a/tests/mkappdir_test.py
+++ b/tests/mkappdir_test.py
@@ -33,8 +33,8 @@ def test_get_output_base() -> None:
 @pytest.mark.parametrize(
     ("path", "expected"),
     [
-        (Path("."), False),
-        (Path(".").resolve(), True),
+        (Path(), False),
+        (Path().resolve(), True),
         (Path(__file__), True),
         (Path("/"), False),
         (Path("bazel-out/stable-status.txt"), False),

--- a/tests/mkappdir_test.py
+++ b/tests/mkappdir_test.py
@@ -1,0 +1,121 @@
+"""Unit tests for mkappdir module."""
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from appimage.private import mkappdir
+
+
+@pytest.mark.parametrize(
+    ("target", "origin", "expected"),
+    [
+        ("/", "/", "."),
+        ("/usr/bin", "/usr", "bin"),
+        ("/usr/bin", "/", "usr/bin"),
+        ("/a/b/c", "/a/b/d", "../c"),
+        ("a/b/c/d", "a/b/d/e", "../../c/d"),
+    ],
+)
+def test_relative_path(target: str, origin: str, expected: str) -> None:
+    relative = mkappdir.relative_path(Path(target), Path(origin))
+    assert relative == Path(expected)
+
+
+def test_get_output_base() -> None:
+    ob = mkappdir.get_output_base()
+    assert __file__.startswith(ob)
+
+
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        (Path("."), False),
+        (Path(".").resolve(), True),
+        (Path(__file__), True),
+        (Path("/"), False),
+        (Path("bazel-out/stable-status.txt"), False),
+        (Path("bazel-out/stable-status.txt").resolve(), True),
+    ],
+)
+def test_is_inside_bazel_cache(path: Path, expected: bool) -> None:
+    inside = mkappdir.is_inside_bazel_cache(path)
+    assert inside == expected
+
+
+@pytest.mark.parametrize("symlinks", [True, False])
+def test_copy_file_or_dir(symlinks: bool) -> None:
+    with tempfile.TemporaryDirectory(suffix=".src") as tmp_dir:
+        src = Path(tmp_dir) / "src"
+        src.mkdir()
+
+        foo = src / "foo"
+        foo.mkdir(mode=0o701)
+
+        bar = foo / "bar"
+        bar.write_text("bar")
+        bar.chmod(0o456)
+        os.utime(bar, (0, 200))
+        os.utime(foo, (0, 100))
+
+        dir = src / "dir"
+        dir.mkdir()
+
+        link = src / "baz/link"
+        link.parent.mkdir()
+        link.symlink_to("../foo/bar")
+
+        dangling = src / "dangling"
+        dangling.symlink_to("invalid")
+
+        dst_link = Path(tmp_dir) / "dstfile/baz/link"
+        dst_bar = Path(tmp_dir) / "dstfile/foo/bar"
+        mkappdir.copy_file_or_dir(link, dst_link, preserve_symlinks=symlinks)
+        mkappdir.copy_file_or_dir(bar, dst_bar, preserve_symlinks=symlinks)
+
+        assert dst_link.exists()
+        assert dst_link.is_symlink() is symlinks
+        assert dst_link.read_text() == "bar"
+
+        dst = Path(tmp_dir) / "dst_dir"
+        mkappdir.copy_file_or_dir(src, dst, preserve_symlinks=symlinks)
+
+        assert set(dst.rglob("*")) == {
+            dst / "foo",
+            dst / "foo/bar",
+            dst / "dir",
+            dst / "baz",
+            dst / "baz/link",
+            dst / "dangling",
+        }
+
+        foo = dst / "foo"
+        assert foo.exists()
+        assert foo.is_dir()
+        assert oct(foo.stat().st_mode) == "0o40701"
+        assert foo.stat().st_mtime == 100
+
+        file = dst / "foo/bar"
+        assert file.read_text() == "bar"
+        assert oct(file.stat().st_mode) == "0o100456"
+        assert file.stat().st_mtime == 200
+
+        link = dst / "baz/link"
+        assert link.exists()
+        assert link.is_file()
+        if symlinks:
+            assert link.readlink() == Path("../foo/bar")
+        else:
+            assert not link.is_symlink()
+        assert link.read_text() == "bar"
+
+        dangling = dst / "dangling"
+        assert dangling.is_symlink()
+        assert not dangling.exists()
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__]))


### PR DESCRIPTION
Added some more unit tests and noticed that `copy_file_or_dir` wasn't doing exactly what I expected it to do for dangling symlinks.