### PR TITLE
Merge steps into a single `AppImage` mnemonic

### DIFF
--- a/appimage/private/BUILD
+++ b/appimage/private/BUILD
@@ -5,3 +5,14 @@ py_binary(
     srcs = ["mkappdir.py"],
     visibility = ["//visibility:public"],
 )
+
+sh_binary(
+    name = "mkappimage",
+    srcs = ["mkappimage.sh"],
+    data = [
+        ":mkappdir",
+        "@squashfs-tools//:mksquashfs",
+    ],
+    visibility = ["//visibility:public"],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
+)

--- a/appimage/private/mkappimage.sh
+++ b/appimage/private/mkappimage.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# --- begin runfiles.bash initialization v3 ---
+# Copy-pasted from the Bazel Bash runfiles library v3.
+set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+# shellcheck disable=SC1090
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+source "$0.runfiles/$f" 2>/dev/null || \
+source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+{ echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v3 ---
+
+set -eu
+
+mkappdir="$(rlocation rules_appimage/appimage/private/mkappdir)"
+mksquashfs="$(rlocation squashfs-tools/mksquashfs)"
+
+manifest="$1"
+shift
+apprun="$1"
+shift
+pseudofile_defs="$1"
+shift
+sqfs="$1"
+shift
+runtime="$1"
+shift
+appimage="$1"
+shift
+
+# Create the mksquashfs pseudo file definitions file.
+# This explains to mksquashfs how to create the AppDir.
+"$mkappdir" --manifest "$manifest" --apprun "$apprun" "$pseudofile_defs"
+
+# Point mksquashfs at an empty dir so it doesn't include any other files
+emptydir="$(mktemp -d)"
+trap 'rm -rf "$emptydir"' EXIT
+
+# Create the squashfs image
+"$mksquashfs" "$emptydir" "$sqfs" -pf "$pseudofile_defs" "$@"
+
+# Create the final AppImage
+# by concatenating the AppImage runtime and the squashfs image of the AppDir
+cat "$runtime" "$sqfs" > "$appimage"

--- a/appimage/private/mkappimage.sh
+++ b/appimage/private/mkappimage.sh
@@ -2,14 +2,21 @@
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
 # shellcheck disable=SC1090
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-source "$0.runfiles/$f" 2>/dev/null || \
-source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-{ echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
+    source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
+    source "$0.runfiles/$f" 2>/dev/null ||
+    source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+    source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
+    {
+        echo >&2 "ERROR: cannot find $f"
+        exit 1
+    }
+f=
+set -e
 # --- end runfiles.bash initialization v3 ---
 
 set -eu
@@ -43,4 +50,4 @@ trap 'rm -rf "$emptydir"' EXIT
 
 # Create the final AppImage
 # by concatenating the AppImage runtime and the squashfs image of the AppDir
-cat "$runtime" "$sqfs" > "$appimage"
+cat "$runtime" "$sqfs" >"$appimage"


### PR DESCRIPTION
Merge steps into a single `AppImage` mnemonic. This makes builds faster, particularly on systems with slow I/O (thinking EBS volumes here) as Bazel doesn't need to shuffle all the inputs around for every action. It also simplifies what needs to be remote-cached and/or executed, so I dropped the `execution_requirements` tags again for now.