### PR TITLE
Fix build determinism

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,6 +48,11 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - run: examples/integration_test.sh
+  determinism:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - run: tests/determinism/reproducible_shas.sh
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -67,4 +67,4 @@ oci.pull(
     image = "docker.io/library/python",
     platforms = ["linux/amd64"],
 )
-use_repo(oci, "python3-slim")
+use_repo(oci, "python3-slim", "python3-slim_linux_amd64")

--- a/appimage/appimage.bzl
+++ b/appimage/appimage.bzl
@@ -13,6 +13,8 @@ MKSQUASHFS_ARGS = [
     "0",
     "-root-time",
     "0",
+    "-all-time",
+    "0",
 ]
 MKSQUASHFS_NUM_PROCS = 4
 MKSQUASHFS_MEM_MB = 1024

--- a/tests/analysis_tests/program.sh
+++ b/tests/analysis_tests/program.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+true

--- a/tests/determinism/reproducible_shas.sh
+++ b/tests/determinism/reproducible_shas.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# When an appimage is rebuilt, the sha256sum of the resulting file must be the same.
+# In other words, the build must be deterministic.
+# We check this by building the same targets twice and comparing the sha256sums.
+
+set -euxo pipefail
+
+query='kind("appimage rule", //...)'
+tempdir="$(mktemp -d)"
+targets="$tempdir/targets"
+files="$tempdir/files"
+trap 'rm -rf "$tempdir"' EXIT
+
+bazel query "$query" >"$targets"
+bazel cquery "$query" --output files >"$files"
+
+bazel build --target_pattern_file="$targets"
+xargs --arg-file="$files" sha256sum | tee "$tempdir/shas0.txt"
+
+xargs --arg-file="$files" rm -f
+
+bazel build --remote_cache= --disk_cache= --target_pattern_file="$targets"
+xargs --arg-file="$files" sha256sum | tee "$tempdir/shas1.txt"
+
+diff -u "$tempdir/shas0.txt" "$tempdir/shas1.txt"


### PR DESCRIPTION
Need to add `-all-time 0` to the mksquashfs args to prevent non-deterministic timestamps of files generated from the pseudo file definitions list.
See https://github.com/plougher/squashfs-tools/issues/288

Also add an integration test that checks if rebuilds have stable hashes.

For some there were two minor issues regarding `bazel mod tidy` and a missing `program.sh`, fixed those as well.