### PR TITLE
Upgrade with_cfg.bzl

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -12,7 +12,7 @@ bazel_dep(name = "squashfs-tools", version = "4.6.1")
 bazel_dep(name = "zstd", version = "1.5.6")
 
 bazel_dep(name = "rules_testing", version = "0.6.0", dev_dependency = True)
-bazel_dep(name = "with_cfg.bzl", version = "0.5.0", dev_dependency = True)
+bazel_dep(name = "with_cfg.bzl", version = "0.6.0", dev_dependency = True)
 
 rules_appimage = use_extension("//:extensions.bzl", "appimage_ext_dependencies")
 use_repo(


### PR DESCRIPTION
Upgrade `with_cfg.bzl` to https://github.com/fmeum/with_cfg.bzl/releases/tag/v0.6.0 to fix `Error: 'struct' value has no field or method 'AppleDebugOutputs'` in https://buildkite.com/bazel/bcr-bazel-compatibility-test/builds/72#019367bc-a37c-4ae9-acf2-4a0ccdfdf8c9 and work towards https://github.com/bazelbuild/bazel-central-registry/issues/3260