### PR TITLE
Add missing files_to_run manifests to fix cc runfiles library

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,7 +6,7 @@ module(
 )
 
 bazel_dep(name = "platforms", version = "0.0.11")
-bazel_dep(name = "rules_cc", version = "0.0.17")
+bazel_dep(name = "rules_cc", version = "0.1.1")
 bazel_dep(name = "rules_python", version = "1.1.0")
 bazel_dep(name = "squashfs-tools", version = "4.6.1")
 bazel_dep(name = "zstd", version = "1.5.7")

--- a/appimage/private/runfiles.bzl
+++ b/appimage/private/runfiles.bzl
@@ -113,7 +113,11 @@ def collect_runfiles_info(ctx):
 
     # Collect everything that needs to be in the appimage and deduplicate using depset.
     runfiles_list = depset(ctx.files.data, transitive = [_default_runfiles(ctx.attr.binary)] + [_default_runfiles(d) for d in ctx.attr.data]).to_list()
+    files_to_run = [ctx.attr.binary[DefaultInfo].files_to_run.repo_mapping_manifest, ctx.attr.binary[DefaultInfo].files_to_run.runfiles_manifest]
+
     file_map = {f.path: _final_file_path(ctx, f) for f in runfiles_list if not f.is_directory}
+    file_map.update({file.path: file.short_path for file in files_to_run})
+
     tree_artifacts_map = {f.path: _final_file_path(ctx, f) for f in runfiles_list if f.is_directory}
 
     # Handle empty_filenames. This is used for some __init__.py files.
@@ -141,6 +145,6 @@ def collect_runfiles_info(ctx):
         tree_artifacts = [struct(src = src, dst = dst) for src, dst in tree_artifacts_map.items()],
     )
     return struct(
-        files = runfiles_list,
+        files = runfiles_list + files_to_run,
         manifest = manifest,
     )

--- a/deps.bzl
+++ b/deps.bzl
@@ -62,6 +62,13 @@ def rules_appimage_development_deps():
     """Declare http_archive deps needed to run tests of rules_appimage."""
     maybe(
         http_archive,
+        name = "rules_cc",
+        sha256 = "712d77868b3152dd618c4d64faaddefcc5965f90f5de6e6dd1d5ddcd0be82d42",
+        strip_prefix = "rules_cc-0.1.1",
+        url = "https://github.com/bazelbuild/rules_cc/releases/download/0.1.1/rules_cc-0.1.1.tar.gz",
+    )
+    maybe(
+        http_archive,
         name = "rules_testing",
         sha256 = "28c2d174471b587bf0df1fd3a10313f22c8906caf4050f8b46ec4648a79f90c3",
         strip_prefix = "rules_testing-0.7.0",

--- a/tests/cc_runfiles/BUILD
+++ b/tests/cc_runfiles/BUILD
@@ -1,0 +1,17 @@
+load("@rules_appimage//appimage:appimage.bzl", "appimage_test")
+load("@rules_cc//cc:defs.bzl", "cc_test")
+
+cc_test(
+    name = "test",
+    timeout = "short",
+    srcs = ["test.cpp"],
+    data = ["@appimage_runtime_aarch64//file"],
+    deps = ["@rules_cc//cc/runfiles"],
+)
+
+appimage_test(
+    name = "test.appimage",
+    timeout = "short",
+    binary = ":test",
+    tags = ["requires-fakeroot"],
+)

--- a/tests/cc_runfiles/test.cpp
+++ b/tests/cc_runfiles/test.cpp
@@ -1,0 +1,27 @@
+
+#include "rules_cc/cc/runfiles/runfiles.h"
+
+#include <cassert>
+#include <filesystem>
+#include <iostream>
+
+using rules_cc::cc::runfiles::Runfiles;
+
+int main(int argc, const char **argv) {
+  assert(argc > 0 && "Failed to get argc");
+  assert(argv[0] != nullptr && "Failed to get argv");
+  std::cout << "argv0: " << argv[0] << std::endl;
+
+  const auto runfiles{Runfiles::Create(argv[0])};
+  assert(runfiles != nullptr && "Failed to load runfiles");
+
+  const auto path =
+      runfiles->Rlocation("appimage_runtime_aarch64/file/downloaded");
+  assert(!path.empty() && "Failed to find external binary");
+  std::cout << "path: " << path << std::endl;
+
+  const auto exists = std::filesystem::exists(path);
+  assert(exists && "external path does not exist");
+
+  return exists ? 0 : 1;
+}


### PR DESCRIPTION
Previously, the `target.runfiles/MANIFEST` and `target.runfiles/_repo_mapping` files were not added to the appimage squashfs.
This caused applications to behave differently when wrapped in an appimage rule as the runfiles libraries could not find the manifests to compute the relations between apparent and canonical repo names.