### PR TITLE
Don't call `/usr/bin/dirname` in AppRun

### DIFF
--- a/appimage/private/mkapprun.bzl
+++ b/appimage/private/mkapprun.bzl
@@ -60,8 +60,9 @@ def _make_apprun_setup_content(ctx):
     apprun_lines.append("export BUILD_WORKING_DIRECTORY")
 
     # Explicitly set RUNFILES_DIR to the runfiles dir of the binary instead of the appimage rule itself
-    apprun_lines.append('workdir="$(dirname "$0")/%s"' % get_workdir(ctx))
-    apprun_lines.append('RUNFILES_DIR="$(dirname "$workdir")"')
+    apprun_lines.append('thisdir="${0%/*}"')  # Same as "$(dirname "$0")"
+    apprun_lines.append('workdir="$thisdir/%s"' % get_workdir(ctx))
+    apprun_lines.append('RUNFILES_DIR="${workdir%/*}"')  # Get parent directory of workdir
     apprun_lines.append("export RUNFILES_DIR")
 
     # Run under runfiles


### PR DESCRIPTION
Don't call `/usr/bin/dirname` in AppRun to improve hermeticity and reduce runtime dependency
```console
❯ type dirname
dirname is /usr/bin/dirname
```