### PR TITLE
Fix `required` CI check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,7 +82,7 @@ jobs:
   required:
     runs-on: ubuntu-latest
     needs: [test, examples, determinism, lint]  # this automatically depends on all matrix jobs
-    if: always() # Never skip, even if dependencies failed (which would otherwise make this one *skip*)
+    if: always()  # Never skip, even if dependencies failed (which would otherwise make this one *skip*)
     steps:
     - name: Fail if any ancestor job failed
       if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}


### PR DESCRIPTION
Properly fail `required` job if any dependent has failed.

<img width="1010" alt="image" src="https://github.com/user-attachments/assets/e408d8fb-f804-4b11-a14b-466958f37430" />
