### PR TITLE
Use sqfs 4.7 relative hard link mode `h`

### DIFF
--- a/appimage/private/mkappdir.py
+++ b/appimage/private/mkappdir.py
@@ -149,7 +149,7 @@ def to_pseudofile_def_lines(src: Path, dst: Path, preserve_symlinks: bool) -> di
     Pseudo file definition formats used here:
     "filename d mode uid gid"               create a directory
     "filename f mode uid gid command"       create file from stdout of command
-    "filename l filename"                   create file from copy (hard-link) of filename
+    "filename h filename"                   create file from copy (hard-link) of filename
     "filename s mode uid gid symlink"       create a symbolic link (mode is ignored)
     """
     operations = {dir.as_posix(): "d 755 0 0" for dir in get_all_parent_dirs(dst)}
@@ -160,7 +160,7 @@ def to_pseudofile_def_lines(src: Path, dst: Path, preserve_symlinks: bool) -> di
     ):
         operations[dst.as_posix()] = f"s 0 0 0 {src.readlink()}"
     elif src.is_file():
-        operations[dst.as_posix()] = f'l "{src.resolve()}"'
+        operations[dst.as_posix()] = f'h "{src}"'
     elif src.is_dir():
         operations[dst.as_posix()] = f"d {src.lstat().st_mode & 0o777:o} 0 0"
     elif not src.exists():
@@ -370,7 +370,7 @@ def write_appdir_pseudofile_defs(manifest: Path, apprun: Path, runfiles_manifest
     """Write a mksquashfs pf file representing the AppDir."""
     pseudofile_defs = make_appdir_pseudofile_defs(manifest, runfiles_manifest)
     lines = [
-        f"AppRun l {apprun.resolve()}",
+        f"AppRun h {apprun}",
         *sorted(f'"{k}" {v}' for k, v in pseudofile_defs.items()),
         "",
     ]

--- a/tests/mkappdir_test.py
+++ b/tests/mkappdir_test.py
@@ -88,19 +88,17 @@ def test_to_pseudofile_def_lines() -> None:
         link = Path("space link")
         link.symlink_to(src)
 
-        base = Path(tmp_dir).resolve()  # this is needed for macOS, which prefixes /private
-
         assert mkdef(src, Path("a/b/c/d"), True) == {
             "a": "d 755 0 0",
             "a/b": "d 755 0 0",
             "a/b/c": "d 755 0 0",
-            "a/b/c/d": f'h "{base}/dir/space file"',
+            "a/b/c/d": 'h "dir/space file"',
         }
-        assert mkdef(src, Path("dst"), True) == {"dst": f'h "{base}/dir/space file"'}
+        assert mkdef(src, Path("dst"), True) == {"dst": 'h "dir/space file"'}
         assert mkdef(dangling, Path("dst"), True) == {"dst": "s 0 0 0 ../invalid"}
         assert mkdef(dangling, Path("dst"), False) == {"dst": "s 0 0 0 ../invalid"}
         assert mkdef(link, Path("dst"), True) == {"dst": "s 0 0 0 dir/space file"}
-        assert mkdef(link, Path("dst"), False) == {"dst": f'h "{base}/dir/space file"'}
+        assert mkdef(link, Path("dst"), False) == {"dst": 'h "space link"'}
 
 
 if __name__ == "__main__":

--- a/tests/mkappdir_test.py
+++ b/tests/mkappdir_test.py
@@ -94,13 +94,13 @@ def test_to_pseudofile_def_lines() -> None:
             "a": "d 755 0 0",
             "a/b": "d 755 0 0",
             "a/b/c": "d 755 0 0",
-            "a/b/c/d": f'l "{base}/dir/space file"',
+            "a/b/c/d": f'h "{base}/dir/space file"',
         }
-        assert mkdef(src, Path("dst"), True) == {"dst": f'l "{base}/dir/space file"'}
+        assert mkdef(src, Path("dst"), True) == {"dst": f'h "{base}/dir/space file"'}
         assert mkdef(dangling, Path("dst"), True) == {"dst": "s 0 0 0 ../invalid"}
         assert mkdef(dangling, Path("dst"), False) == {"dst": "s 0 0 0 ../invalid"}
         assert mkdef(link, Path("dst"), True) == {"dst": "s 0 0 0 dir/space file"}
-        assert mkdef(link, Path("dst"), False) == {"dst": f'l "{base}/dir/space file"'}
+        assert mkdef(link, Path("dst"), False) == {"dst": f'h "{base}/dir/space file"'}
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Using `h` pseudo file definition from https://github.com/plougher/squashfs-tools/commit/58fab67d4a1b974b938ebc37c369449216a4ff2b removes absolute paths (which were necessary because of https://github.com/plougher/squashfs-tools/commit/58fab67d4a1b974b938ebc37c369449216a4ff2b) from the optional `.pseudofile_defs.txt` output.

Compare `bazel-bin/tests/appimage_test_sh.pseudofile_defs.txt` when running ` bazel build //tests:appimage_test_sh --output_groups appimage_debug --platforms //:linux_x86_64`

Before:
```
AppRun l /private/var/tmp/_bazel_laltenmueller/62b467eb38cd779b06b4f1f1a7ca9ad5/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/tests/appimage_test_sh.AppRun
"tests" d 755 0 0
"tests/test_sh" s 0 0 0 test_sh.runfiles/_main/tests/test_sh
"tests/test_sh.repo_mapping" l "/private/var/tmp/_bazel_laltenmueller/62b467eb38cd779b06b4f1f1a7ca9ad5/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/tests/test_sh.repo_mapping"
"tests/test_sh.runfiles" d 755 0 0
"tests/test_sh.runfiles/MANIFEST" l "/private/var/tmp/_bazel_laltenmueller/62b467eb38cd779b06b4f1f1a7ca9ad5/sandbox/darwin-sandbox/669/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/tests/appimage_test_sh.runfiles_manifest.txt"
"tests/test_sh.runfiles/_main" d 755 0 0
"tests/test_sh.runfiles/_main/external" s 0 0 0 ..
"tests/test_sh.runfiles/_main/tests" d 755 0 0
"tests/test_sh.runfiles/_main/tests/test.sh" l "/Users/laltenmueller/rules_appimage/tests/test.sh"
"tests/test_sh.runfiles/_main/tests/test_sh" l "/Users/laltenmueller/rules_appimage/tests/test.sh"
```

After:
```
AppRun h bazel-out/darwin_arm64-fastbuild/bin/tests/appimage_test_sh.AppRun
"tests" d 755 0 0
"tests/test_sh" s 0 0 0 test_sh.runfiles/_main/tests/test_sh
"tests/test_sh.repo_mapping" h "bazel-out/darwin_arm64-fastbuild/bin/tests/test_sh.repo_mapping"
"tests/test_sh.runfiles" d 755 0 0
"tests/test_sh.runfiles/MANIFEST" h "bazel-out/darwin_arm64-fastbuild/bin/tests/appimage_test_sh.runfiles_manifest.txt"
"tests/test_sh.runfiles/_main" d 755 0 0
"tests/test_sh.runfiles/_main/external" s 0 0 0 ..
"tests/test_sh.runfiles/_main/tests" d 755 0 0
"tests/test_sh.runfiles/_main/tests/test.sh" h "tests/test.sh"
"tests/test_sh.runfiles/_main/tests/test_sh" h "bazel-out/darwin_arm64-fastbuild/bin/tests/test_sh"
```