### PR TITLE
download url uses tag now, not version

### DIFF
--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,6 +1,6 @@
 {
   "integrity": "",
   "strip_prefix": "{REPO}-{VERSION}",
-  "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/{REPO}-{VERSION}.tar.gz",
+  "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/{REPO}-{TAG}.tar.gz",
   "docs_url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/{REPO}-{TAG}.docs.tar.gz"
 }


### PR DESCRIPTION
Should fix
```
Fetching release archive https://github.com/lalten/rules_appimage/releases/download/v1.20.0-rc1/rules_appimage-1.20.0-rc1.tar.gz
Failed to download artifact; Request failed with status code 404
```
from https://github.com/bazel-contrib/publish-to-bcr/blob/d5e7cfa40eeb82eb0031f748d1d03c491535f9b5/src/domain/create-entry.ts#L55