### PR TITLE
Set up bazel-contrib/setup-bazel

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,10 +54,14 @@ jobs:
           flags:
     steps:
     - uses: actions/checkout@v6
-    - name: Use BuildBuddy RW API key instead of public readonly key
-      run: sed -i.bak 's#x-buildbuddy-api-key=.*#x-buildbuddy-api-key=${{ env.BUILDBUDDY_RW_API_KEY }}#' .bazelrc
-      if: ${{ env.BUILDBUDDY_RW_API_KEY }}
-    - run: echo "common ${{ matrix.flags }}" >> .bazelrc
+    - uses: bazel-contrib/setup-bazel@0.19.0
+      with:
+        bazelisk-cache: true
+        disk-cache: ${{ github.workflow }}
+        repository-cache: true
+        bazelrc: |
+          ${{ env.BUILDBUDDY_RW_API_KEY && format('build --remote_header=x-buildbuddy-api-key={0}', env.BUILDBUDDY_RW_API_KEY) }}
+          common ${{ matrix.flags }}
 
     # Don't want to bother with hundreds of lines of Workspace setup for the rules_pycross compat test
     - if: matrix.external_dependency_system == 'workspace' || matrix.os == 'macos'
@@ -75,11 +79,20 @@ jobs:
         bazel-version: [7.x, 8.x, 9.x]
     steps:
     - uses: actions/checkout@v6
+    - uses: bazel-contrib/setup-bazel@0.19.0
+      with:
+        bazelisk-cache: true
+        disk-cache: ${{ github.workflow }}-examples
+        repository-cache: true
     - run: examples/integration_test.sh
   determinism:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
+    - uses: bazel-contrib/setup-bazel@0.19.0
+      with:
+        bazelisk-cache: true
+        repository-cache: true
     - run: tests/determinism/reproducible_shas.sh
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Set up https://github.com/bazel-contrib/setup-bazel for repository and disk cache. Buildbuddy remote cache is still the same (RW in CI, RO locally)