### PR TITLE
fix(docs): fix update_docs for stardoc 0.8

### DIFF
--- a/third_party/stardoc.diff
+++ b/third_party/stardoc.diff
@@ -13,7 +13,7 @@
 new file mode 100644
 --- /dev/null
 +++ stardoc/stardoc_with_diff_test.bzl
-@@ -0,0 +1,86 @@
+@@ -0,0 +1,84 @@
 +load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
 +load("@bazel_skylib//rules:write_file.bzl", "write_file")
 +load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
@@ -80,10 +80,8 @@ new file mode 100644
 +    content = ["#!/usr/bin/env bash", "cd ${BUILD_WORKSPACE_DIRECTORY}"]
 +    data = []
 +    for r in native.existing_rules().values():
-+        if r["kind"] == "stardoc":
-+            doc_gen = r["out"]
-+            if doc_gen.startswith(":"):
-+                doc_gen = doc_gen[1:]
++        if r["kind"] == "stardoc_markdown_renderer":
++            doc_gen = r["name"] + ".md"
 +            doc_dest = doc_gen.replace("-docgen.md", ".md")
 +            data.append(doc_gen)
 +            content.append("cp -fv bazel-bin/{0}/{1} {2}".format(docs_folder, doc_gen, doc_dest))

--- a/third_party/stardoc.diff
+++ b/third_party/stardoc.diff
@@ -82,7 +82,7 @@ new file mode 100644
 +    for r in native.existing_rules().values():
 +        if r["kind"] == "stardoc_markdown_renderer":
 +            doc_gen = r["name"] + ".md"
-+            doc_dest = doc_gen.replace("-docgen.md", ".md")
++            doc_dest = "{}/{}".format(docs_folder, doc_gen.replace("-docgen.md", ".md"))
 +            data.append(doc_gen)
 +            content.append("cp -fv bazel-bin/{0}/{1} {2}".format(docs_folder, doc_gen, doc_dest))
 +


### PR DESCRIPTION
This PR fixes docs generation not working after updating to aspect_bazel_lib/bazel_lib and stardoc 0.8.1.
The `update_docs` shell script was dropping the file copying logic entirely. The macro logic to inspect `stardoc` targets needed to be updated to look for `stardoc_markdown_renderer` targets.

Fixes #415.